### PR TITLE
Update ltoworkarounds.conf

### DIFF
--- a/package.env/ltoworkarounds.conf
+++ b/package.env/ltoworkarounds.conf
@@ -51,3 +51,6 @@ sys-devel/gdb lto/nolto.conf
 dev-lang/spidermonkey lto/nolto.conf
 net-misc/nx O2lto/nolto.conf
 net-wireless/aircrack-ng lto/nolto.conf
+app-office/libreoffice lto/nolto.conf # configure: error: Your gcc is not -fvisibility=hidden safe. This is no longer supported.
+net-libs/webkit-gtk:3 lto/nolto.conf
+net-libs/webkit-gtk:4 lto/nolto.conf


### PR DESCRIPTION
I also need `ltofat` for `app-editors/vim-8.0.0386::gentoo  USE="X acl gpm lua luajit nls perl python -cscope -debug -minimal -racket -ruby (-selinux) -tcl -vim-pager" PYTHON_TARGETS="python2_7 python3_4 (-python3_5) (-python3_6)"`, but since you seem to be able to emerge it without problems, I decided against adding it.