### PR TITLE
Add app-editors/vim to ltoworkarounds.conf

### DIFF
--- a/package.env/ltoworkarounds.conf
+++ b/package.env/ltoworkarounds.conf
@@ -17,6 +17,7 @@ media-libs/x264 lto/ltofat.conf
 net-wireless/mdk lto/ltofat.conf
 sys-boot/syslinux lto/ltofat.conf
 mail-mta/nullmailer lto/ltofat.conf
+app-editors/vim lto/ltofat.conf # required for perl USE flag
 
 #Packages which cannot be built with LTO at all
 dev-qt/qtcore lto/nolto.conf

--- a/package.env/ltoworkarounds.conf
+++ b/package.env/ltoworkarounds.conf
@@ -51,3 +51,6 @@ sys-devel/gdb lto/nolto.conf
 dev-lang/spidermonkey lto/nolto.conf
 net-misc/nx O2lto/nolto.conf
 net-wireless/aircrack-ng lto/nolto.conf
+app-office/libreoffice lto/nolto.conf # configure: error: Your gcc is not -fvisibility=hidden safe. This is no longer supported.
+net-libs/webkit-gtk:3 lto/nolto.conf
+net-libs/webkit-gtk:4 lto/nolto.conf


### PR DESCRIPTION
Vim doesn’t build with LTO with perl support, but builds fine without it.