### PR TITLE
Pkg moarvm made ltofat.conf so nqp and rakudo can build for Perl6.

### DIFF
--- a/sys-config/ltoize/files/package.env/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.env/ltoworkarounds.conf
@@ -18,6 +18,7 @@ net-wireless/mdk lto/ltofat.conf
 sys-boot/syslinux lto/ltofat.conf
 mail-mta/nullmailer lto/ltofat.conf
 app-editors/vim lto/ltofat.conf # required for perl USE flag
+dev-lang/moarvm lto/ltofat.conf # required for perl6 (i.e., dev-lang/nqp and dev-lang/rakudo to build)
 
 #Packages which cannot be built with LTO at all (nolto.conf)
 dev-qt/qtcore lto/nolto.conf


### PR DESCRIPTION
The package moarvm (an indirect dependency for Perl6) needs to be ltofat.conf for dev-lang/nqp and dev-lang/rakudo to compile and link.