### PR TITLE
media-sound/jack2: LTO not recommended

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -29,7 +29,6 @@ dev-qt/qtscript *FLAGS-=-flto*
 media-libs/alsa-lib *FLAGS-=-flto*
 dev-libs/wayland *FLAGS-=-flto*
 dev-libs/elfutils *FLAGS-=-flto* 
-net-misc/openssh *FLAGS-=-flto* #hangs on exit with lto
 #sys-apps/grep *FLAGS-=-flto* #verify this
 sys-libs/ncurses *FLAGS-=-flto*
 dev-qt/qtwebengine *FLAGS-=-flto*
@@ -60,6 +59,12 @@ net-libs/webkit-gtk:3 *FLAGS-=-flto*
 net-libs/webkit-gtk:4 *FLAGS-=-flto*
 media-video/mplayer *FLAGS-=-flto*
 kde-apps/dolphin *FLAGS-=-flto*
+
+# BEGIN: LTO not recommended  
+# Packages which can be built with LTO but leads to problems/crashes/segfaults
+media-sound/jack2 *FLAGS-=-flto* # segfault in libjack.so.0.1.0 when ANY app trying to use it (breaks everithing built w/ JACK support)
+net-misc/openssh *FLAGS-=-flto* # hangs on exit with lto
+# END: LTO not recommended
 
 # BEGIN: genkernel no LTO needs for initramfs use of LVM + LUKS
 sys-apps/util-linux *FLAGS-=-flto*


### PR DESCRIPTION
Patched for GCC7: https://bugs.gentoo.org/629570

[ 5411.704512] pulseaudio[17609]: segfault at 7f04ceeb8096 ip 00007f04beb3a8af sp 00007ffdf5fecef0 error 4 in libjack.so.0.1.0[7f04beb28000+38000]
[ 5439.833653] calfjackhost[17699]: segfault at 7f0cde2a908e ip 00007f0cdc707a7f sp 00007f0cca282bc0 error 4 in libjack.so.0.1.0[7f0cdc6f9000+38000]
[ 5488.924652] qjackctl[16377]: segfault at 559bdd7ae068 ip 00007f15c61eedfe sp 00007ffcf9c3c260 error 6 in libc-2.26.so[7f15c60d9000+1bf000]

I created separate section for packages w/ similar problems to make the list more informative.