### PR TITLE
Support more LTOed packages

### DIFF
--- a/sys-config/ltoize/files/make.conf.lto
+++ b/sys-config/ltoize/files/make.conf.lto
@@ -2,6 +2,14 @@
 #It's usually a good idea to set this to the number of hardware threads in your system
 FLTO="-flto=8"
 
+# https://bugs.gentoo.org/603594
+# Keep all static libraries unstripped.
+# This should allow you to omit almost all -ffat-lto-objects flags and build many more packages with LTO.
+# After enabling this you must rebuild all packages providing static libraries with LTO support.
+# Use $ `equery b -n $(find /lib* /usr/lib* -type f -name "*.a" 2>/dev/null)` | sort | uniq
+# or # `emerge -1va $(find /lib* /usr/lib* -type f -name "*.a" 2>/dev/null)` commands to get corresponding list.
+STRIP_MASK="*.a"
+
 #GRAPHITE contains Graphite specific optimizations and other optimizations that are disabled at O3
 #but don't influence the compiler's judgement.
 #These should be updated with GCC 7.2.1 (-ftree-loop-distribution may be enabled


### PR DESCRIPTION
I have all packages built w/ this for now and no noticeable problems so far. The only `-flto` overrides left is (as have some build errors):
```sh
media-libs/alsa-lib
media-libs/flac
```

and this two (unstable w/ LTO):
```sh
net-misc/openssh
media-sound/jack2
```
Some other locally patched to be built w/ LTO or have additional flags.
So for now I have ~1K packages installed and still no any `-ffat-lto-objects` flags set.