### PR TITLE
Use some overrides only for specified USE-flag

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -3,7 +3,7 @@
 dev-haskell/* *FLAGS+=-ffat-lto-objects #This is so non-portage GHC compilations work, as GHC is oblivious to LTO.  portage builds are fine.
 media-libs/x264 *FLAGS+=-ffat-lto-objects
 sys-boot/syslinux *FLAGS+=-ffat-lto-objects
-app-editors/vim *FLAGS+="$(use perl && echo -n '-ffat-lto-objects')" # required for perl USE flag
+app-editors/vim "has perl ${IUSE//+} && use perl && FlagAddAllFlags -ffat-lto-objects" # required for perl USE flag
 dev-lang/moarvm *FLAGS+=-ffat-lto-objects # required for perl6 (i.e., dev-lang/nqp and dev-lang/rakudo to build)
 sci-libs/mpir *FLAGS+=-ffat-lto-objects # compilation error without fat LTO (not linking error)
 
@@ -24,7 +24,7 @@ media-sound/pulseaudio *FLAGS-=-flto*
 dev-db/mariadb *FLAGS-=-flto*
 sci-libs/arrayfire *FLAGS-=-flto*
 dev-lang/perl *FLAGS-=-flto*
-net-misc/dhcp *FLAGS-="$(use server && echo -n '-flto*')" # Cannot be built with LTO by default, but can if "server" USE is disabled
+net-misc/dhcp "has server ${IUSE//+} && use server && FlagSubAllFlags -flto*" # Cannot be built with LTO by default, but can if "server" USE is disabled
 sys-devel/gdb *FLAGS-=-flto*
 dev-lang/spidermonkey *FLAGS-=-flto*
 net-misc/nx *FLAGS-=-flto*
@@ -100,7 +100,7 @@ sys-fs/dmraid *FLAGS-=-flto*
 #Packages which Graphite optimizations don't play nice with
 # BEGIN: Graphite ICE (Internal Compiler Error)
 # Report them to GCC team
-app-emulation/wine* *FLAGS-="$(use custom-cflags && echo -n '-flto*' $GRAPHITE)" # +custom-cflags # In function ‘arc2polybezier’: gdiplus.c:223:5: internal compiler error: in extract_affine, at graphite-sese-to-poly.c:272
+app-emulation/wine* "has custom-cflags ${IUSE//+} && use custom-cflags && FlagSubAllFlags -flto* ${MY_GRAPHITE}" # In function ‘arc2polybezier’: gdiplus.c:223:5: internal compiler error: in extract_affine, at graphite-sese-to-poly.c:272
 media-libs/libvorbis *FLAGS-="${GRAPHITE}" # In function 'run_test': sharedbook.c:543:6: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 media-video/ffmpeg *FLAGS-=-flto* *FLAGS-="${GRAPHITE}" # In function ‘ff_nelly_get_sample_bits’: nellymoser.c:116:6: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 # END: Graphite ICE (Internal Compiler Error)

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -100,7 +100,7 @@ sys-fs/dmraid *FLAGS-=-flto*
 #Packages which Graphite optimizations don't play nice with
 # BEGIN: Graphite ICE (Internal Compiler Error)
 # Report them to GCC team
-app-emulation/wine* "has custom-cflags ${IUSE//+} && use custom-cflags && FlagSubAllFlags -flto* ${MY_GRAPHITE}" # In function ‘arc2polybezier’: gdiplus.c:223:5: internal compiler error: in extract_affine, at graphite-sese-to-poly.c:272
+app-emulation/wine* "has custom-cflags ${IUSE//+} && use custom-cflags && FlagSubAllFlags -flto* ${GRAPHITE}" # In function ‘arc2polybezier’: gdiplus.c:223:5: internal compiler error: in extract_affine, at graphite-sese-to-poly.c:272
 media-libs/libvorbis *FLAGS-="${GRAPHITE}" # In function 'run_test': sharedbook.c:543:6: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 media-video/ffmpeg *FLAGS-=-flto* *FLAGS-="${GRAPHITE}" # In function ‘ff_nelly_get_sample_bits’: nellymoser.c:116:6: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 # END: Graphite ICE (Internal Compiler Error)

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -3,7 +3,7 @@
 dev-haskell/* *FLAGS+=-ffat-lto-objects #This is so non-portage GHC compilations work, as GHC is oblivious to LTO.  portage builds are fine.
 media-libs/x264 *FLAGS+=-ffat-lto-objects
 sys-boot/syslinux *FLAGS+=-ffat-lto-objects
-app-editors/vim *FLAGS+=-ffat-lto-objects # required for perl USE flag
+app-editors/vim *FLAGS+="$(use perl && echo -n '-ffat-lto-objects')" # required for perl USE flag
 dev-lang/moarvm *FLAGS+=-ffat-lto-objects # required for perl6 (i.e., dev-lang/nqp and dev-lang/rakudo to build)
 sci-libs/mpir *FLAGS+=-ffat-lto-objects # compilation error without fat LTO (not linking error)
 
@@ -24,7 +24,7 @@ media-sound/pulseaudio *FLAGS-=-flto*
 dev-db/mariadb *FLAGS-=-flto*
 sci-libs/arrayfire *FLAGS-=-flto*
 dev-lang/perl *FLAGS-=-flto*
-net-misc/dhcp *FLAGS-=-flto* # Cannot be built with LTO by default, but can if "server" USE is disabled
+net-misc/dhcp *FLAGS-="$(use server && echo -n '-flto*')" # Cannot be built with LTO by default, but can if "server" USE is disabled
 sys-devel/gdb *FLAGS-=-flto*
 dev-lang/spidermonkey *FLAGS-=-flto*
 net-misc/nx *FLAGS-=-flto*
@@ -100,7 +100,7 @@ sys-fs/dmraid *FLAGS-=-flto*
 #Packages which Graphite optimizations don't play nice with
 # BEGIN: Graphite ICE (Internal Compiler Error)
 # Report them to GCC team
-app-emulation/wine* *FLAGS-=-flto* *FLAGS-="${GRAPHITE}" # +custom-cflags # In function ‘arc2polybezier’: gdiplus.c:223:5: internal compiler error: in extract_affine, at graphite-sese-to-poly.c:272
+app-emulation/wine* *FLAGS-="$(use custom-cflags && echo -n '-flto*' $GRAPHITE)" # +custom-cflags # In function ‘arc2polybezier’: gdiplus.c:223:5: internal compiler error: in extract_affine, at graphite-sese-to-poly.c:272
 media-libs/libvorbis *FLAGS-="${GRAPHITE}" # In function 'run_test': sharedbook.c:543:6: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 media-video/ffmpeg *FLAGS-=-flto* *FLAGS-="${GRAPHITE}" # In function ‘ff_nelly_get_sample_bits’: nellymoser.c:116:6: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 # END: Graphite ICE (Internal Compiler Error)


### PR DESCRIPTION
There is possible to add some logic to `*FLAGS` ( https://github.com/vaeth/portage-bashrc-mv/issues/8#issuecomment-338497760 ) so we can check is USE-flag set etc. You probably may want to add similar logic for `BEGIN: genkernel no LTO needs for initramfs use of LVM + LUKS` block and other packages.