### PR TITLE
games-emulation/{parallel-n64-libretro,mupen64plus-libretro} fails to…

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -44,6 +44,8 @@ app-emulation/virtualbox-extpack-oracle *FLAGS-=-flto*
 kde-apps/kdenlive *FLAGS-=-flto*
 games-action/extreme-tuxracer *FLAGS-=-flto*
 app-office/scribus *FLAGS-=-flto* # Scribus crashes on startup if compiled with LTO
+games-emulation/parallel-n64-libretro *FLAGS-=-flto*
+games-emulation/mupen64plus-libretro *FLAGS-=-flto*
 
 sys-process/criu *FLAGS-=-pipe* *FLAGS-=-flto* *FLAGS-="-fuse-linker-plugin" LDFLAGS-="-Wl,--hash-style=gnu" *FLAGS-="${GRAPHITE}" # Fewer settings may be possible. Needs testing. (Dependency of LXC.)
 


### PR DESCRIPTION
… compile with lto

Title: <category>/<package>: <description>

Ensure that any added workarounds have a comment explaining the compilation error which requires it.
Any removed workarounds should be moved to the fixed section.
If an issue exists, please link it.
See CONTRIBUTING.md for more information.
