### PR TITLE
dev-lang/php: fix LTO for version >= 7.2

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -136,4 +136,4 @@ sys-libs/ncurses LDFLAGS+=-ldl # checking whether able to link to dl*() function
 media-libs/mesa *FLAGS-=-Wl,--as-needed # strange LTO linking bug that causes pthreads to be thrown out early under LTO (#50)
 kde-apps/dolphin *FLAGS-="-Wl,--as-needed" # ( https://github.com/InBetweenNames/gentooLTO/issues/50 )
 sys-devel/gcc *FLAGS-=-flto*
-dev-lang/php *FLAGS+="-flto-partition=max" # error: global register variable follows a function definition
+dev-lang/php "export EXTRA_ECONF=--disable-gcc-global-regs" # or dev-lang/php *FLAGS+="-flto-partition=max" for < 7.2 # https://bugs.php.net/bug.php?id=72702


### PR DESCRIPTION
*FLAGS+="-flto-partition=max" don't work for dev-lang/php:7.2 anymore