### PR TITLE
Added exclusions to pass pgo profile tests, overcome permission errors

### DIFF
--- a/dev-lang/python/python-3.4.6-r2.ebuild
+++ b/dev-lang/python/python-3.4.6-r2.ebuild
@@ -179,7 +179,7 @@ src_compile() {
 
 	cd "${BUILD_DIR}" || die
 	if use pgo; then
-		emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_sundry test_curses test_distutils test_imaplib test_import test_asyncio"
+		emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_sundry test_curses test_distutils test_imaplib test_import test_asyncio test_compileall test_pyexpat test_runpy test_support test_threaded_import test_xmlrpc_net"
 	else
 		emake CPPFLAGS= CFLAGS= LDFLAGS=
 	fi

--- a/dev-lang/python/python-3.5.4-r2.ebuild
+++ b/dev-lang/python/python-3.5.4-r2.ebuild
@@ -176,7 +176,7 @@ src_compile() {
 
 	cd "${BUILD_DIR}" || die
 	if use pgo; then
-		emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_asyncio"
+		emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_asyncio test_compileall test_pyexpat test_runpy test_support test_threaded_import test_xmlrpc_net"
 	else
 		emake CPPFLAGS= CFLAGS= LDFLAGS=
 	fi

--- a/dev-lang/python/python-3.6.4-r1.ebuild
+++ b/dev-lang/python/python-3.6.4-r1.ebuild
@@ -164,7 +164,7 @@ src_compile() {
 	local -x LC_ALL=C
 
 	if use pgo; then
-		emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_asyncio test_ctypes"
+		emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_asyncio test_ctypes test_compileall test_pyexpat test_runpy test_support test_threaded_import test_xmlrpc_net"
 	else
 		emake CPPFLAGS= CFLAGS= LDFLAGS=
 	fi

--- a/dev-lang/python/python-3.6.4-r1.ebuild
+++ b/dev-lang/python/python-3.6.4-r1.ebuild
@@ -164,7 +164,7 @@ src_compile() {
 	local -x LC_ALL=C
 
 	if use pgo; then
-                emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_asyncio test_ctypes"
+		emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_asyncio test_ctypes"
 	else
 		emake CPPFLAGS= CFLAGS= LDFLAGS=
 	fi

--- a/dev-lang/python/python-3.6.4-r1.ebuild
+++ b/dev-lang/python/python-3.6.4-r1.ebuild
@@ -164,7 +164,7 @@ src_compile() {
 	local -x LC_ALL=C
 
 	if use pgo; then
-		emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_asyncio test_ctypes"
+                emake profile-opt PROFILE_TASK="-m test.regrtest -w -uall,-audio -x test_gdb test_multiprocessing test_subprocess test_tokenize test_signal test_faulthandler test_asyncio test_ctypes"
 	else
 		emake CPPFLAGS= CFLAGS= LDFLAGS=
 	fi


### PR DESCRIPTION
Title: <category>/<package>: <description>

Ensure that any added workarounds have a comment explaining the compilation error which requires it.
Any removed workarounds should be moved to the fixed section.
If an issue exists, please link it.
See CONTRIBUTING.md for more information.
