### PR TITLE
Disable LTO for x11-drivers/xf86-video-intel

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -48,6 +48,7 @@ sys-libs/libcxxabi *FLAGS-=-flto* # /var/tmp/portage/sys-libs/libcxxabi-4.0.1/te
 games-emulation/parallel-n64-libretro *FLAGS-=-flto*
 games-emulation/mupen64plus-libretro *FLAGS-=-flto*
 net-p2p/cpuminer-opt *FLAGS-=-flto*
+x11-drivers/xf86-video-intel *FLAGS-=-flto*
 
 sys-process/criu *FLAGS-=-pipe* *FLAGS-=-flto* *FLAGS-="-fuse-linker-plugin" LDFLAGS-="-Wl,--hash-style=gnu" *FLAGS-="${GRAPHITE}" # Fewer settings may be possible. Needs testing. (Dependency of LXC.)
 


### PR DESCRIPTION
currently `xf86-video-intel` does not build with LTO. disabling it fixes the issue.

**Relevant build error:**
`error: inlining failed in call to always_inline ‘memcpy’: target specific option mismatch`
which apparently, is a [GCC memory starvation issue](https://bugs.freedesktop.org/show_bug.cgi?id=77580)