### PR TITLE
app-text/mupdf: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -49,6 +49,7 @@ games-emulation/parallel-n64-libretro *FLAGS-=-flto*
 games-emulation/mupen64plus-libretro *FLAGS-=-flto*
 net-p2p/cpuminer-opt *FLAGS-=-flto*
 x11-drivers/xf86-video-intel *FLAGS-=-flto*
+app-text/mupdf *FLAGS-=-flto*
 
 sys-process/criu *FLAGS-=-pipe* *FLAGS-=-flto* *FLAGS-="-fuse-linker-plugin" LDFLAGS-="-Wl,--hash-style=gnu" *FLAGS-="${GRAPHITE}" # Fewer settings may be possible. Needs testing. (Dependency of LXC.)
 

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -49,12 +49,11 @@ games-emulation/parallel-n64-libretro *FLAGS-=-flto*
 games-emulation/mupen64plus-libretro *FLAGS-=-flto*
 net-p2p/cpuminer-opt *FLAGS-=-flto*
 x11-drivers/xf86-video-intel *FLAGS-=-flto*
-app-text/mupdf *FLAGS-=-flto*
+<app-text/mupdf-1.12.0 *FLAGS-=-flto* # Only older versions are affected
 
 sys-process/criu *FLAGS-=-pipe* *FLAGS-=-flto* *FLAGS-="-fuse-linker-plugin" LDFLAGS-="-Wl,--hash-style=gnu" *FLAGS-="${GRAPHITE}" # Fewer settings may be possible. Needs testing. (Dependency of LXC.)
 
 # BEGIN: Packages known as FIXED
-#app-text/mupdf *FLAGS-=-flto*
 #dev-libs/botan *FLAGS-=-flto*
 #dev-libs/libgcrypt *FLAGS-=-flto*
 #dev-libs/wayland *FLAGS-=-flto*


### PR DESCRIPTION
the build currently fails with the following error:

```
Error: can't resolve `.rodata' {.rodata section} - `.Ltext0' {.text section}
gcc error: ld-wrapper failed.
```
disabling lto fixes it.