### PR TITLE
app-misc/vlock: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -50,6 +50,10 @@ games-emulation/mupen64plus-libretro *FLAGS-=-flto*
 net-p2p/cpuminer-opt *FLAGS-=-flto*
 x11-drivers/xf86-video-intel *FLAGS-=-flto*
 
+# gcc: error trying to exec '/usr/libexec/gcc/x86_64-pc-linux-gnu/7.3.0/collect2': execv: Argument list too long
+# I think this has more to do with the build system than the LTO itself
+app-misc/vlock *FLAGS-=-flto*
+
 sys-process/criu *FLAGS-=-pipe* *FLAGS-=-flto* *FLAGS-="-fuse-linker-plugin" LDFLAGS-="-Wl,--hash-style=gnu" *FLAGS-="${GRAPHITE}" # Fewer settings may be possible. Needs testing. (Dependency of LXC.)
 
 # BEGIN: Packages known as FIXED


### PR DESCRIPTION
Title: app-misc/vlock: fails with ```gcc: error trying to exec '/usr/libexec/gcc/x86_64-pc-linux-gnu/7.3.0/collect2': execv: Argument list too long``` unless I disable LTO completely.

from the error log it seems like it's more of a build system problem than LTO itself

full log https://gist.github.com/anonymous/cd87a7af30314bbb9d90ec49073294e4