### PR TITLE
=media-libs/openjpeg-2.3.0 doesnt compile with graphite, #98

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -129,6 +129,7 @@ media-libs/libvorbis *FLAGS-="${GRAPHITE}" # In function 'run_test': sharedbook.
 media-video/ffmpeg *FLAGS-=-flto* *FLAGS-="${GRAPHITE}" # NOTE: Depending on your CPUFLAGS this may work with LTO.  The SSE intrinsics seem to cause problems in some cases.   Graphite error: In function ‘ff_nelly_get_sample_bits’: nellymoser.c:116:6: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 net-misc/nx *FLAGS-=-flto* *FLAGS-="${GRAPHITE}"
 =media-libs/openal-1.18.2* *FLAGS-="${GRAPHITE}" # ../openal-soft-1.18.2/Alc/bformatdec.c:418:6: internal compiler error: in add_phi_arg_for_new_expr, at graphite-isl-ast-to-gimple.c:2321
+=media-libs/openjpeg-2.3.0 *FLAGS-="${GRAPHITE}" # ../openjp2/dwt.c:2171:13: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 # END: Graphite ICE (Internal Compiler Error)
 
 #Packages which don't play nice with glibc 2.26 or have other build problems not related to this configuration


### PR DESCRIPTION
Fix for issue #98 