### PR TITLE
dev-scheme/racket: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -50,6 +50,7 @@ games-emulation/mupen64plus-libretro *FLAGS-=-flto*
 net-p2p/cpuminer-opt *FLAGS-=-flto*
 x11-drivers/xf86-video-intel *FLAGS-=-flto*
 <app-text/mupdf-1.12.0 *FLAGS-=-flto* # Only older versions are affected
+dev-scheme/racket *FLAGS-=-flto* #cdar: contract violation \   expected: (cons/c pair? any/c) \   given: #f
 
 # gcc: error trying to exec '/usr/libexec/gcc/x86_64-pc-linux-gnu/7.3.0/collect2': execv: Argument list too long
 # I think this has more to do with the build system than the LTO itself


### PR DESCRIPTION
Doesn't seem to build with full LTO or with fat objects enabled.

Build log: [dev-scheme:racket-6.12:20180221-014120.txt](https://github.com/InBetweenNames/gentooLTO/files/1742660/dev-scheme.racket-6.12.20180221-014120.txt)
