### PR TITLE
app-emulation/wine*: can be built with graphite

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -124,7 +124,7 @@ sys-fs/dmraid *FLAGS-=-flto*
 #Packages which Graphite optimizations don't play nice with
 # BEGIN: Graphite ICE (Internal Compiler Error)
 # Report them to GCC team
-app-emulation/wine* "has custom-cflags ${IUSE//+} && use custom-cflags && FlagSubAllFlags -flto* ${GRAPHITE}" # In function ‘arc2polybezier’: gdiplus.c:223:5: internal compiler error: in extract_affine, at graphite-sese-to-poly.c:272
+app-emulation/wine* "has custom-cflags ${IUSE//+} && use custom-cflags && FlagSubAllFlags -flto*"
 games-emulation/ppsspp *FLAGS-="${GRAPHITE}" # In function ‘Int_Vtfm’: ../ppsspp-1.4.2/Core/MIPS/MIPSIntVFPU.cpp:1322:7: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 kde-apps/kreversi *FLAGS-="${GRAPHITE}" # internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019
 media-libs/libvorbis *FLAGS-="${GRAPHITE}" # In function 'run_test': sharedbook.c:543:6: internal compiler error: in outer_projection_mupa, at graphite-sese-to-poly.c:1019


### PR DESCRIPTION
`app-emulation/wine-staging` compiles for me with GCC 8.1.0 and graphite enabled.