### PR TITLE
dev-db/mysql-connector-c: Added LTO exception to allow compilation

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -10,6 +10,7 @@ sci-libs/mpir *FLAGS+=-ffat-lto-objects # compilation error without fat LTO (not
 app-emulation/qemu *FLAGS-=-flto* *FLAGS+=-fno-strict-aliasing # required to compile qemu
 media-libs/alsa-lib *FLAGS-=-flto*
 dev-libs/elfutils *FLAGS-=-flto* 
+dev-db/mysql-connector-c *FLAGS-=-flto* # required to compiled mysql-connector-c
 dev-qt/qtwebengine *FLAGS-=-flto* #needs retest
 dev-qt/qtwebkit *FLAGS-=-flto* 
 dev-lang/rust *FLAGS-=-flto*


### PR DESCRIPTION
Noticed a failure for dev-db/mysql-connector-c when utilizing LTO. Added exception and compilation proceeds normally. Please let me know if there are any issues.

Thanks!