### PR TITLE
dev-qt/qtscript: increase -=-flto range to 5.9.6

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -66,7 +66,7 @@ app-misc/vlock *FLAGS-=-flto*
 
 sys-process/criu *FLAGS-=-pipe* *FLAGS-=-flto* *FLAGS-="-fuse-linker-plugin" LDFLAGS-="-Wl,--hash-style=gnu" *FLAGS-="${GRAPHITE}" # Fewer settings may be possible. Needs testing. (Dependency of LXC.)
 
->=dev-qt/qtscript-5.10.1 *FLAGS-=-flto*
+>=dev-qt/qtscript-5.9.6 *FLAGS-=-flto*
 
 # BEGIN: Packages known as FIXED
 #dev-libs/botan *FLAGS-=-flto*


### PR DESCRIPTION
[failed build.log](https://github.com/InBetweenNames/gentooLTO/files/2241881/dev-qt.qtscript-5.9.6.20180730-135949.log)

[passed build.log](https://github.com/InBetweenNames/gentooLTO/files/2241897/dev-qt.qtscript-5.9.6.20180730-135949.log)
