### PR TITLE
dev-lang/php: address #135 (linking for >=php-7.2)

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -59,6 +59,7 @@ sys-libs/libsemanage *FLAGS-=-flto*
 gnome-base/gnome-keyring *FLAGS-=-flto*
 dev-libs/weston *FLAGS-=-flto*
 app-crypt/veracrypt *FLAGS-=-flto*
+>=dev-lang/php-7.2.0 *FLAGS-=-flto* # lto-wrapper link failure / https://github.com/InBetweenNames/gentooLTO/issues/135
 
 # gcc: error trying to exec '/usr/libexec/gcc/x86_64-pc-linux-gnu/7.3.0/collect2': execv: Argument list too long
 # I think this has more to do with the build system than the LTO itself


### PR DESCRIPTION
Reference build error:

```
/bin/sh /var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/libtool --silent --preserve-dup-deps --mode=install cp ext/opcache/opcache.la /var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/modules
/var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/ext/curl/interface.c: In function '_php_curl_setopt':
/var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/ext/curl/interface.c:2803:4: warning: call to '_curl_easy_setopt_err_progress_cb' declared with attribute warning: curl_easy_setopt expects a curl_progress_callback argument for this option
    curl_easy_setopt(ch->cp, CURLOPT_PROGRESSFUNCTION, curl_progress);
    ^
/var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/Zend/zend_vm_execute.h: In function 'ZEND_TICKS_SPEC_HANDLER':
/var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/Zend/zend_execute.c:66:40: error: global register variable follows a function definition
   register zend_execute_data* volatile execute_data __asm__(ZEND_VM_FP_GLOBAL_REG);
                                        ^
/var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/Zend/zend_vm_execute.h: In function 'ZEND_NULL_HANDLER':
/var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/Zend/zend_execute.c:83:36: error: global register variable follows a function definition
   register const zend_op* volatile opline __asm__(ZEND_VM_IP_GLOBAL_REG);
                                    ^
/var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/Zend/zend_vm_execute.h: In function 'zend_vm_call_opcode_handler':
/var/tmp/portage/dev-lang/php-7.2.7/work/sapis-build/cli/Zend/zend_execute.c:66:40: error: global register variable follows a function definition
   register zend_execute_data* volatile execute_data __asm__(ZEND_VM_FP_GLOBAL_REG);
                                        ^
make[1]: *** [/var/tmp/portage/dev-lang/php-7.2.7/temp/cc0r6IWB.mk:74: /var/tmp/portage/dev-lang/php-7.2.7/temp/ccqqywCI.ltrans24.ltrans.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [/var/tmp/portage/dev-lang/php-7.2.7/temp/cc0r6IWB.mk:86: /var/tmp/portage/dev-lang/php-7.2.7/temp/ccqqywCI.ltrans28.ltrans.o] Error 1
lto-wrapper: fatal error: make returned 2 exit status
compilation terminated.
/usr/lib/gcc/x86_64-pc-linux-gnu/8.1.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
make: *** [Makefile:274: sapi/cli/php] Error 1
```

Tested and reproduced with GCC 8.2, binutils 2.31.1, php 7.2.8