### PR TITLE
sys-apps/gawk: disable -fipa-pta

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -174,3 +174,5 @@ sys-devel/gcc *FLAGS-=-flto* #Internal compiler error when used with PGO
 dev-lisp/clisp *FLAGS+=-falign-functions # Issue #128.  Function alignment problem.
 net-p2p/retroshare *FLAGS-=-flto* # Issue #129, ICE on amd64
 net-misc/lksctp-tools *FLAGS-=-flto* # function `main': <artificial>:(.text.startup+0x16de): undefined reference to `sctp_connectx'
+
+sys-apps/gawk *FLAGS-=-fipa-pta # during IPA pass: pta lto1: internal compiler error: Segmentation fault


### PR DESCRIPTION
[build.txt](https://github.com/InBetweenNames/gentooLTO/files/2485412/build.txt)
[info.txt](https://github.com/InBetweenNames/gentooLTO/files/2485413/info.txt)

```
x86_64-pc-linux-gnu-gcc  -march=native -O3 -fgraphite-identity -floop-nest-optimize -flto=4 -fipa-pta -fuse-linker-plugin -pipe -fomit-frame-pointer -Wl,-O1 -Wl,--as-needed -Wl,--hash-style=gnu -DNDEBUG  -Wl,-O1 -Wl,--as-needed -Wl,--hash-style=gnu -march=native -O3 -fgraphite-identity -floop-nest-optimize -flto=4 -fipa-pta -fuse-linker-plugin -pipe -fomit-frame-pointer -Wl,-export-dynamic -o gawk array.o awkgram.o builtin.o cint_array.o command.o debug.o dfa.o eval.o ext.o field.o floatcomp.o gawkapi.o gawkmisc.o getopt.o getopt1.o int_array.o io.o main.o mpfr.o msg.o node.o profile.o random.o re.o regex.o replace.o str_array.o symbol.o version.o    -lreadline  -ldl -lm 
during IPA pass: pta
lto1: internal compiler error: Segmentation fault
Please submit a full bug report,
with preprocessed source if appropriate.
See <https://bugs.gentoo.org/> for instructions.
make[3]: *** [/tmp/portage/sys-apps/gawk-4.1.4/temp/ccQUTyyf.mk:20: /tmp/portage/sys-apps/gawk-4.1.4/temp/ccuZnJp1.ltrans6.ltrans.o] Error 1
make[3]: *** Waiting for unfinished jobs....
lto-wrapper: fatal error: make returned 2 exit status
compilation terminated.
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:659: gawk] Error 1
make[2]: Leaving directory '/tmp/portage/sys-apps/gawk-4.1.4/work/gawk-4.1.4'
make[1]: *** [Makefile:742: all-recursive] Error 1
make[1]: Leaving directory '/tmp/portage/sys-apps/gawk-4.1.4/work/gawk-4.1.4'
make: *** [Makefile:562: all] Error 2
```