### PR TITLE
sys-apps/exa: fails to link to git2 with fat LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -8,6 +8,7 @@ sci-libs/mpir *FLAGS+=-ffat-lto-objects # compilation error without fat LTO (not
 app-crypt/efitools *FLAGS+=-ffat-lto-objects # textrel?
 dev-util/cargo *FLAGS+=-ffat-lto-objects # fails to link against git2 functions without
 x11-terms/alacritty *FLAGS+=-ffat-lto-objects
+sys-apps/exa *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 media-libs/mesa *FLAGS-=-flto* #*FLAGS-=-Wl,--as-needed # strange LTO linking bug that causes pthreads to be thrown out early under LTO (#50)


### PR DESCRIPTION
`sys-apps/exa` fails to build with fat LTO, for the same reasons I guess that `cargo` does.
