### PR TITLE
sys-devel/llvm with SEMINTERPOS makes DXVK crash

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -116,3 +116,4 @@ net-misc/lksctp-tools *FLAGS-=-flto* # function `main': <artificial>:(.text.star
 =sys-apps/gawk-4.1.4 *FLAGS-=-fipa-pta # during IPA pass: pta lto1: internal compiler error: Segmentation fault
 >=www-client/firefox-60.0_beta14 *FLAGS-="${IPA}" /-O3/-O2 LTO_ENABLE_FLAGOMATIC=yes # latest FF beta doesn't like -O3, forgets sessions between runs.  ICE on -fipa-pta.
 dev-qt/qtwebkit *FLAGS-=${IPA}
+sys-devel/llvm *FLAGS-=${SEMINTERPOS}


### PR DESCRIPTION
Compiling llvm with semantic flag causes wine with DXVK either freeze or crash. Steam play/Proton is also affected, however native vulkan games on Linux is unaffected like RoTTR.
My gpu: AMD VEGA 64