### PR TITLE
x11-misc/polybar: use emake instead of ninja

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -117,3 +117,7 @@ net-misc/lksctp-tools *FLAGS-=-flto* # function `main': <artificial>:(.text.star
 >=www-client/firefox-60.0_beta14 *FLAGS-="${IPA}" /-O3/-O2 LTO_ENABLE_FLAGOMATIC=yes # latest FF beta doesn't like -O3, forgets sessions between runs.  ICE on -fipa-pta.
 dev-qt/qtwebkit *FLAGS-=${IPA}
 sys-devel/llvm *FLAGS-=${SEMINTERPOS}
+
+# BEGIN: Will not build with ninja
+x11-misc/polybar CMAKE_MAKEFILE_GENERATOR=emake
+# END: Will not build with ninja


### PR DESCRIPTION
Polybar will not build with ninja; added line to use emake. See [issue](https://github.com/InBetweenNames/gentooLTO/issues/175)
