### PR TITLE
app-crypt/efitools: disable LTO for package and dependency sys-boot/gnu-efi

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -5,7 +5,6 @@ sys-boot/syslinux *FLAGS+=-ffat-lto-objects #Requires ld.bfd
 app-editors/vim "has perl ${IUSE//+} && use perl && FlagAddAllFlags -ffat-lto-objects" # required for perl USE flag
 dev-lang/moarvm *FLAGS+=-ffat-lto-objects # required for perl6 (i.e., dev-lang/nqp and dev-lang/rakudo to build)
 sci-libs/mpir *FLAGS+=-ffat-lto-objects # compilation error without fat LTO (not linking error)
-app-crypt/efitools *FLAGS+=-ffat-lto-objects # textrel?
 dev-util/cargo *FLAGS+=-ffat-lto-objects # fails to link against git2 functions without
 x11-terms/alacritty *FLAGS+=-ffat-lto-objects
 sys-apps/exa *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
@@ -75,6 +74,8 @@ sci-electronics/kicad *FLAGS-=-flto* # Issue #168
 kde-frameworks/kjs *FLAGS-=-flto* # Issue #181
 dev-scheme/guile *FLAGS-=-flto* # Issue #193
 dev-libs/libsigsegv *FLAGS-=-flto* # Issue #189
+sys-boot/gnu-efi *FLAGS-=-flto*
+app-crypt/efitools *FLAGS-=-flto*
 
 # BEGIN: LTO not recommended  
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
=app-crypt/efitools-1.8.1 would fail compilation as follows:
```
ld -nostdlib -shared -Bsymbolic /usr/lib/crt0-efi-x86_64.o -L /usr/lib -L /usr/lib -L /usr/lib64 -T elf_x86_64_efi.lds HelloWorld.o lib/lib-efi.a -o HelloWorld.so -lefi -lgnuefi /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/libgcc.a
/usr/lib/libefi.a(data.o): plugin needed to handle lto object
/usr/lib/libefi.a(init.o): plugin needed to handle lto object
/usr/lib/libefi.a(misc.o): plugin needed to handle lto object
/usr/lib/libefi.a(print.o): plugin needed to handle lto object
/usr/lib/libefi.a(str.o): plugin needed to handle lto object
/usr/lib/libgnuefi.a(reloc_x86_64.o): plugin needed to handle lto object
# check we have no undefined symbols
nm -D HelloWorld.so | grep ' U ' && exit 1 || exit 0
nm: HelloWorld.so: plugin needed to handle lto object
                 U AllocatePool
                 U BS
                 U CopyMem
                 U FreePool
                 U InitializeLib
                 U Print
                 U SPrint
                 U ST
                 U StrLen
                 U _relocate
make: *** [Make.rules:66: HelloWorld.so] Error 1
```
Removing LTO for app-crypt/efitools and its dependency sys-boot/gnu-efi allowed for it to build successfully. Submitting this PR with hopes that somebody may have a better idea for a solution.