### PR TITLE
sys-apps/acl fails to set ACLs if built with LTO.

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -79,6 +79,7 @@ net-p2p/retroshare *FLAGS-=-flto* # Issue #129, ICE on amd64
 net-misc/lksctp-tools *FLAGS-=-flto* # function `main': <artificial>:(.text.startup+0x16de): undefined reference to `sctp_connectx'
 sys-devel/gcc "has pgo ${IUSE//+} && use pgo && FlagSubAllFlags -flto*" #Internal compiler error when used with PGO
 dev-lang/mono *FLAGS-=-flto*
+sys-apps/acl *FLAGS-=-flto* # Issue #209, builds fine but we cannot set any acl value using the program.
 
 # BEGIN: LTO not recommended  
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
See #209 

Basically, it builds fine but we cannot set any ACLs at all.