### PR TITLE
dev-scheme/racket: fails to build with LTO and -fipa-pta

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -54,7 +54,7 @@ games-emulation/mupen64plus-libretro *FLAGS-=-flto*
 net-p2p/cpuminer-opt *FLAGS-=-flto*
 x11-drivers/xf86-video-intel *FLAGS-=-flto*
 <app-text/mupdf-1.12.0 *FLAGS-=-flto* # Only older versions are affected
-dev-scheme/racket *FLAGS-=-flto* #cdar: contract violation \   expected: (cons/c pair? any/c) \   given: #f
+dev-scheme/racket *FLAGS-=-flto* *FLAGS-="${IPA}" # Undefined references and multiple segfaults / violations during build.
 sys-libs/libsepol *FLAGS-=-flto*
 sys-libs/libselinux *FLAGS-=-flto*
 sys-libs/libsemanage *FLAGS-=-flto*


### PR DESCRIPTION
Signed-off-by: Andrew Attali <me@aphypnise.eu>

Racket needs to be built without LTO and -fipa-pta, since some references are used by the racket compiler during installation. This prevents segfaults and undefined references.