### PR TITLE
dev-java/openjdk: fails to build without LTO off.

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -80,6 +80,7 @@ net-misc/lksctp-tools *FLAGS-=-flto* # function `main': <artificial>:(.text.star
 sys-devel/gcc "has pgo ${IUSE//+} && use pgo && FlagSubAllFlags -flto*" #Internal compiler error when used with PGO
 dev-lang/mono *FLAGS-=-flto*
 sys-apps/acl *FLAGS-=-flto* # Issue #209, builds fine but we cannot set any acl value using the program.
+dev-java/openjdk *FLAGS-=-flto* # Issue #204, undefined references with LTO.
 
 # BEGIN: LTO not recommended  
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
See #204

Signed-off-by: Andrew Attali <me@aphypnise.eu>