### PR TITLE
dev-lisp/sbcl: cannot build with -fipa-pta

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -142,7 +142,8 @@ www-client/torbrowser *FLAGS-="${IPA}" #ICE on -fipa-pta
 dev-qt/qtwebkit *FLAGS-="${IPA}"
 media-sound/mpc *FLAGS-="${IPA}" # hangs on exit with -fipa-pta
 dev-lang/R *FLAGS-="${IPA}" # during IPA pass: pta lto1: internal compiler error: Segmentation fault
-sys-devel/gcc *FLAGS-="${IPA}" 
+sys-devel/gcc *FLAGS-="${IPA}"
+dev-lisp/sbcl *FLAGS-="${IPA}" #ICE on -fipa-pta
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds


### PR DESCRIPTION
Compiling SBCL fails during IPA pass.