### PR TITLE
Fix GCC version number in warning message

### DIFF
--- a/sys-config/ltoize/ltoize-0.8.1.ebuild
+++ b/sys-config/ltoize/ltoize-0.8.1.ebuild
@@ -28,7 +28,7 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 8.2.0; then
-		ewarn "Warning: Active GCC version < 7.2.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version < 8.2.0, it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
 			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die

--- a/sys-config/ltoize/ltoize-0.8.2.ebuild
+++ b/sys-config/ltoize/ltoize-0.8.2.ebuild
@@ -28,7 +28,7 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 8.2.0; then
-		ewarn "Warning: Active GCC version < 7.2.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version < 8.2.0, it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
 			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die

--- a/sys-config/ltoize/ltoize-0.9.0.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.0.ebuild
@@ -28,7 +28,7 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 8.2.0; then
-		ewarn "Warning: Active GCC version < 7.2.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version < 8.2.0, it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
 			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die

--- a/sys-config/ltoize/ltoize-0.9.1.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.1.ebuild
@@ -28,7 +28,7 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 8.2.0; then
-		ewarn "Warning: Active GCC version < 7.2.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version < 8.2.0, it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
 			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die


### PR DESCRIPTION
I am not sure, but GCC version in warning message is not equal to "${ACTIVE_GCC}" -lt 8.2.0