### PR TITLE
net-fs/autofs: no-semantic-interposition segfaults

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -156,4 +156,5 @@ dev-lang/mono *FLAGS-="-mtls-dialect=gnu2"
 # BEGIN: Semantic Interposition workarounds
 sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
 sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
+net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
 # END: Semantic Interposition Workarounds


### PR DESCRIPTION
With -fno-semantic-interposition builds fine but crashes with:

> automount[9179]: segfault at 0 ip 00007ff50bd65488 sp 00007fffa36d3070 error 4 in lookup_file.so[7ff50bd4c000+36000]