### PR TITLE
media-libs/ilmbase: -lrt needed to build openexr

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -101,6 +101,7 @@ net-misc/nx *FLAGS-=-flto* #Multiple ODR violations
 
 #Packages which require build workarounds to be built with LTO that can be resolved directly in *FLAGS
 sys-devel/gettext *FLAGS+=-lm # needed for linker to resolve libm's log10 -- only needed for LTO
+media-libs/ilmbase *FLAGS+=-lrt # needed for linker to build media-libs/openexr with LTO
 x11-libs/wxGTK NOLDADD=1
 #dev-qt/qtcore "export EXTRA_CXXFLAGS='${CXXFLAGS}' EXTRA_LFLAGS='${LDFLAGS}'" #work around overwritten flags (#32)
 sys-libs/ncurses *FLAGS-=-Wl,--as-needed *FLAGS+=-ldl # checking whether able to link to dl*() functions... configure: error: Cannot link test program for libdl (#111)


### PR DESCRIPTION
Building media-libs/openexr with LTO fails with:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib32/libIlmThread.so: undefined reference to `pthread_create'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib32/libIlmThread.so: undefined reference to `sem_wait'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib32/libIlmThread.so: undefined reference to `sem_init'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib32/libIlmThread.so: undefined reference to `sem_destroy'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib32/libIlmThread.so: undefined reference to `sem_getvalue'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib32/libIlmThread.so: undefined reference to `sem_post'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib32/libIlmThread.so: undefined reference to `sem_trywait'
```

if media-libs/ilmbase was built without -lrt