### PR TITLE
dev-lang/ocaml: disable GRAPHITE due to ICE

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -97,6 +97,7 @@ net-misc/nx *FLAGS-=-flto* #Multiple ODR violations
 #Packages which Graphite optimizations don't play nice with
 # BEGIN: Graphite ICE (Internal Compiler Error)
 # Report them to GCC team
+dev-lang/ocaml *FLAGS-="${GRAPHITE}"
 # END: Graphite ICE (Internal Compiler Error)
 
 #Packages which require build workarounds to be built with LTO that can be resolved directly in *FLAGS


### PR DESCRIPTION
[build.log with GRAPHITE enabled](https://ptpb.pw/es8N.log)
[build.log without GRAPHITE enabled](https://ptpb.pw/oxmD.log)