### PR TITLE
sys-apps/bat: fails to link

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -9,6 +9,7 @@ app-crypt/efitools *FLAGS+=-ffat-lto-objects # textrel?
 dev-util/cargo *FLAGS+=-ffat-lto-objects # fails to link against git2 functions without
 x11-terms/alacritty *FLAGS+=-ffat-lto-objects
 sys-apps/exa *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
+sys-apps/bat *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 media-libs/mesa *FLAGS-=-flto* #*FLAGS-=-Wl,--as-needed # strange LTO linking bug that causes pthreads to be thrown out early under LTO (#50)


### PR DESCRIPTION
```
undefined reference to 'git_repository_discover'
undefined reference to 'git_repository_open'
undefined reference to 'ansi256_from_rgb'
undefined reference to 'ansi256_from_rgb'
undefined reference to 'OnigEncodingUTF8'
undefined reference to 'onig_search_with_param'
undefined reference to 'mz_deflate'
undefined reference to 'mz_deflateInit2'
undefined reference to 'mz_inflateInit2'
undefined reference to 'mz_inflate'
undefined reference to 'mz_deflateEnd'
undefined reference to 'mz_inflateEnd'
undefined reference to 'onig_region_free'
undefined reference to 'onig_free_match_param'
undefined reference to 'onig_error_code_to_str'
undefined reference to 'OnigDefaultSyntax'
undefined reference to 'OnigEncodingUTF8'
undefined reference to 'onig_new'
undefined reference to 'onig_error_code_to_str'
undefined reference to 'onig_new_match_param'
undefined reference to 'onig_initialize_match_param'
undefined reference to 'onig_get_encoding'
undefined reference to 'OnigEncodingUTF8'
undefined reference to 'onig_search_with_param'
undefined reference to 'onig_free_match_param'
undefined reference to 'onig_error_code_to_str'
undefined reference to 'onig_free_match_param'
undefined reference to 'onig_region_free'
undefined reference to 'onig_get_encoding'
undefined reference to 'onig_free'
undefined reference to 'onig_new_match_param'
undefined reference to 'onig_initialize_match_param'
undefined reference to 'onig_free_match_param'
undefined reference to 'onig_region_free'
undefined reference to 'onig_region_free'
undefined reference to 'OnigDefaultSyntax'
undefined reference to 'onig_region_resize'
undefined reference to 'onig_region_copy'
undefined reference to 'git_repository_workdir'
undefined reference to 'git_diff_index_to_workdir'
undefined reference to 'git_diff_index_to_workdir'
undefined reference to 'git_repository_free'
undefined reference to 'giterr_last'
undefined reference to 'giterr_last'
undefined reference to 'giterr_clear'
undefined reference to 'git_diff_foreach'
undefined reference to 'git_diff_free'
undefined reference to 'git_diff_init_options'
undefined reference to 'git_buf_free'
undefined reference to 'git_libgit2_init'
undefined reference to 'git_libgit2_init'
```

As an added general note to this project, I recently finished a world rebuild with 1435 packages.
The system is a stable amd64 with a long list of ~amd64 packages. I needed to add some to the list to build with glibc2.28. Besides my personal selection of ~amd64 I used those suggested in the README.md, following closely the **How to use this configuration**.
It seems to work fine, except nvidia-settings not working (drivers >=410 don't work at all for me), a few Steam games crashing at start and Spotify can't find CURL_GNUTLS_3 in libcurl.so.4, even if built with CURL_SSL="gnutls". This thing of precompiled binaries not finding stuff happened at least 5 times (often complaining also about missing OPENLDAP_2.4_2 in libldap_r-2.4.so.2 and liblber-2.4.so.2 , but I extracted a binary libcurl from Ubuntu so it could that).
I made binary packages of everything I installed and I will probably try a full rebuild with a plain "-O2 -march=native -pipe -mfpmath=sse" to see if that fixes anything.

Thank you for this project, it's cool.