### PR TITLE
Added workaround for sci-visualization/paraview

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -85,6 +85,7 @@ sys-apps/acl *FLAGS-=-flto* # Issue #209, builds fine but we cannot set any acl 
 dev-java/openjdk *FLAGS-=-flto* # Issue #204, undefined references with LTO.
 sys-apps/nix *FLAGS-=-flto* # Issue #222, LTO causes runtime failures
 sys-apps/fwupd *FLAGS-=-flto* # Issue #225, LTO causes runtime failures
+sci-visualization/paraview *FLAGS-=-flto*
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Similar to https://github.com/InBetweenNames/gentooLTO/issues/129, compilation fails with error:
`lto1: internal compiler error: in get_odr_type, at ipa-devirt.c:2098`
Removing LTO allowed it to compile.
