### PR TITLE
net-im/qtox: Disable LTO to solve compilation error

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -86,6 +86,7 @@ dev-java/openjdk *FLAGS-=-flto* # Issue #204, undefined references with LTO.
 sys-apps/nix *FLAGS-=-flto* # Issue #222, LTO causes runtime failures
 sys-apps/fwupd *FLAGS-=-flto* # Issue #225, LTO causes runtime failures
 sci-visualization/paraview *FLAGS-=-flto*
+net-im/qtox *FLAGS-=-flto*
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
**Compilation error:**
```
[ 83%] Linking CXX executable qtox
/usr/bin/cmake -E cmake_link_script CMakeFiles/qtox.dir/link.txt --verbose=1
/usr/bin/x86_64-pc-linux-gnu-g++  -march=skylake -falign-functions=32 -O3 -fgraphite-identity -floop-nest-optimize -fipa-pta -fno-semantic-interposition -flto=7 -fuse-linker-plugin -pipe -Wl,-O1 -Wl,--as-needed -Wl,--hash-style=gnu -std=c++11 -fno-exceptions -fno-rtti -Wstrict-overflow -Wstrict-aliasing -Werror -fstack-protector-all -Wstack-protector  -Wl,-O1 -Wl,--as-needed -Wl,--hash-style=gnu -march=skylake -falign-functions=32 -O3 -fgraphite-identity -floop-nest-optimize -fipa-pta -fno-semantic-interposition -flto=7 -fuse-linker-plugin -pipe -Wl,-z,now -Wl,-z,relro -rdynamic CMakeFiles/qtox.dir/qrc_res.cpp.o CMakeFiles/qtox.dir/qrc_translations.cpp.o CMakeFiles/qtox.dir/qrc_emojione.cpp.o CMakeFiles/qtox.dir/qrc_smileys.cpp.o CMakeFiles/qtox.dir/src/main.cpp.o CMakeFiles/qtox.dir/qtox_autogen/mocs_compilation.cpp.o  -o qtox libqtox_static.a /usr/lib64/libQt5Network.so.5.11.3 /usr/lib64/libQt5OpenGL.so.5.11.3 /usr/lib64/libQt5Svg.so.5.11.3 /usr/lib64/libQt5Widgets.so.5.11.3 /usr/lib64/libQt5Xml.so.5.11.3 -lavcodec -lavdevice -lavformat -lavutil -lexif -lqrencode -lsodium -lswscale -lsqlcipher -lvpx -lm -ltoxcore -lopenal -lX11 -lXss /usr/lib64/libQt5Gui.so.5.11.3 /usr/lib64/libQt5Core.so.5.11.3
../qTox-1.16.3/src/widget/genericchatroomwidget.h:33:7: error: virtual table of type 'struct GenericChatroomWidget' violates one definition rule   [-Werror=odr]
 class GenericChatroomWidget : public GenericChatItemWidget
       ^
qtox_static_autogen/WFD7YQQOTJ/../../../qTox-1.16.3/src/widget/genericchatroomwidget.h:33:7: note: the conflicting type defined in another translation unit
 class GenericChatroomWidget : public GenericChatItemWidget
       ^
<built-in>: note: virtual method '__cxa_pure_virtual'
../qTox-1.16.3/src/widget/genericchatroomwidget.h:44:27: note: ought to match virtual method 'getFriend' but does not
     virtual const Friend* getFriend() const
                           ^
../qTox-1.16.3/src/model/contact.h:26:7: error: virtual table of type 'struct Contact' violates one definition rule   [-Werror=odr]
 class Contact : public QObject
       ^
../qTox-1.16.3/src/model/contact.h:26:7: note: the conflicting type defined in another translation unit
 class Contact : public QObject
       ^
<built-in>: note: virtual method '__cxa_pure_virtual'
/usr/include/qt5/QtCore/qobject.h:127:18: note: ought to match virtual method 'event' but does not
     virtual bool event(QEvent *event);
                  ^
../qTox-1.16.3/src/widget/form/genericchatform.h:57:7: error: virtual table of type 'struct GenericChatForm' violates one definition rule   [-Werror=odr]
 class GenericChatForm : public QWidget
       ^
qtox_static_autogen/SLJ37JTCO3/../../../qTox-1.16.3/src/widget/form/genericchatform.h:57:7: note: the conflicting type defined in another translation unit
 class GenericChatForm : public QWidget
       ^
<built-in>: note: virtual method '__cxa_pure_virtual'
../qTox-1.16.3/src/widget/form/genericchatform.cpp:652:6: note: ought to match virtual method 'clearChatArea' but does not
 void GenericChatForm::clearChatArea(bool notinform)
      ^
../qTox-1.16.3/src/audio/audio.h:33:7: error: virtual table of type 'struct Audio' violates one definition rule [-Werror=odr]
 class Audio : public QObject
       ^
../qTox-1.16.3/src/audio/audio.h:33:7: note: the conflicting type defined in another translation unit has virtual table with more entries
 class Audio : public QObject
       ^
../qTox-1.16.3/src/model/profile/iprofileinfo.h:24:7: error: virtual table of type 'struct IProfileInfo' violates one definition rule [-Werror=odr]
 class IProfileInfo : public QObject
       ^
qtox_static_autogen/MW7LQWBARY/../../../qTox-1.16.3/src/model/profile/iprofileinfo.h:24:7: note: the conflicting type defined in another translation unit has virtual table with more entries
 class IProfileInfo : public QObject
       ^
../qTox-1.16.3/src/video/videosource.h:30:7: error: virtual table of type 'struct VideoSource' violates one definition rule [-Werror=odr]
 class VideoSource : public QObject
       ^
../qTox-1.16.3/src/video/videosource.h:30:7: note: the conflicting type defined in another translation unit has virtual table with more entries
 class VideoSource : public QObject
       ^
../qTox-1.16.3/src/chatlog/chatlinecontent.h:27:7: error: virtual table of type 'struct ChatLineContent' violates one definition rule   [-Werror=odr]
 class ChatLineContent : public QObject, public QGraphicsItem
       ^
qtox_static_autogen/EVTMR7QAUN/../../../qTox-1.16.3/src/chatlog/chatlinecontent.h:27:7: note: the conflicting type defined in another translation unit
 class ChatLineContent : public QObject, public QGraphicsItem
       ^
<built-in>: note: virtual method '__cxa_pure_virtual'
../qTox-1.16.3/src/chatlog/chatlinecontent.cpp:87:6: note: ought to match virtual method 'visibilityChanged' but does not
 void ChatLineContent::visibilityChanged(bool)
      ^
lto1: all warnings being treated as errors
lto-wrapper: fatal error: /usr/bin/x86_64-pc-linux-gnu-g++ returned 1 exit status
compilation terminated.
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/qtox.dir/build.make:3265: qtox] Error 1
make[2]: Leaving directory '/var/tmp/portage/net-im/qtox-1.16.3/work/qtox-1.16.3_build'
make[1]: *** [CMakeFiles/Makefile2:74: CMakeFiles/qtox.dir/all] Error 2
make[1]: Leaving directory '/var/tmp/portage/net-im/qtox-1.16.3/work/qtox-1.16.3_build'
make: *** [Makefile:130: all] Error 2
```