### PR TITLE
Added -fipa-pta workaround for libwebp.

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -152,6 +152,7 @@ media-sound/mpc *FLAGS-="${IPA}" # hangs on exit with -fipa-pta
 dev-lang/R *FLAGS-="${IPA}" # during IPA pass: pta lto1: internal compiler error: Segmentation fault
 sys-devel/gcc *FLAGS-="${IPA}"
 dev-lisp/sbcl *FLAGS-="${IPA}" #ICE on -fipa-pta
+media-libs/libwebp *FLAGS-=-fipa-pta # no compilation issues, but -fipa-pta causes webp images to be displayed incorrectly
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds


### PR DESCRIPTION
media-libs/libwebp: -fipa-pta causes browsers (tested with firefox and chrome) to incorrectly display webp images.
