### PR TITLE
Added workaround for app-emulation/libguestfs

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -87,6 +87,7 @@ sys-apps/nix *FLAGS-=-flto* # Issue #222, LTO causes runtime failures
 sys-apps/fwupd *FLAGS-=-flto* # Issue #225, LTO causes runtime failures
 sci-visualization/paraview *FLAGS-=-flto*
 net-im/qtox *FLAGS-=-flto*
+app-emulation/libguestfs *FLAGS-=-flto*
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
=app-emulation/libguestfs-1.38.6 compilation fails with the following error:
`libtool: link: x86_64-pc-linux-gnu-gcc -o /var/tmp/portage/app-emulation/libguestfs-1.38.6/work/libguestfs-1.38.6/gobject/tmp-introspectwljek7i2/.libs/Guestfs-1.0 -march=native -O3 -fgraphite-identity -floop-nes
t-optimize -fipa-pta -fno-semantic-interposition -flto=8 -fuse-linker-plugin -pipe -falign-functions=32 -Wl,-O1 -Wl,--hash-style=gnu -fno-strict-overflow -Wno-strict-overflow /var/tmp/portage/app-emulation/libgu
estfs-1.38.6/work/libguestfs-1.38.6/gobject/tmp-introspectwljek7i2/Guestfs-1.0.o -Wl,--export-dynamic -pthread -Wl,-O1 -Wl,--hash-style=gnu -march=native -O3 -fgraphite-identity -floop-nest-optimize -fipa-pta -f
no-semantic-interposition -flto=8 -fuse-linker-plugin -pipe -falign-functions=32 -Wl,--export-dynamic  -L. ./.libs/libguestfs-gobject-1.0.so ../lib/.libs/libguestfs.so -lgio-2.0 -lgobject-2.0 -lgmodule-2.0 -lgli
b-2.0 -Wl,--as-needed -pthread`
`Command '['/var/tmp/portage/app-emulation/libguestfs-1.38.6/work/libguestfs-1.38.6/gobject/tmp-introspectwljek7i2/Guestfs-1.0', '--introspect-dump=/var/tmp/portage/app-emulation/libguestfs-1.38.6/work/libguestfs-1.38.6/gobject/tmp-introspectwljek7i2/functions.txt,/var/tmp/portage/app-emulation/libguestfs-1.38.6/work/libguestfs-1.38.6/gobject/tmp-introspectwljek7i2/dump.xml']' died with <Signals.SIGSEGV: 11>.`

Disabling LTO allowed it to compile.