### PR TITLE
media-gfx/shotwell: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -87,7 +87,7 @@ sys-apps/nix *FLAGS-=-flto* # Issue #222, LTO causes runtime failures
 sys-apps/fwupd *FLAGS-=-flto* # Issue #225, LTO causes runtime failures
 sci-visualization/paraview *FLAGS-=-flto*
 net-im/qtox *FLAGS-=-flto*
-media-gfx/shotwell *FLAGS-=-flto*
+media-gfx/shotwell *FLAGS-=-flto* #Library search error with LTO enabled
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -87,6 +87,7 @@ sys-apps/nix *FLAGS-=-flto* # Issue #222, LTO causes runtime failures
 sys-apps/fwupd *FLAGS-=-flto* # Issue #225, LTO causes runtime failures
 sci-visualization/paraview *FLAGS-=-flto*
 net-im/qtox *FLAGS-=-flto*
+media-gfx/shotwell *FLAGS-=-flto*
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Shotwell does not build with LTO enabled.