### PR TITLE
dev-qt/designer: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -12,6 +12,7 @@ sys-apps/exa *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 sys-apps/bat *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
+dev-qt/designer *FLAGS-=-flto*
 dev-util/perf *FLAGS-=-flto*
 media-libs/mesa *FLAGS-=-flto* #*FLAGS-=-Wl,--as-needed # strange LTO linking bug that causes pthreads to be thrown out early under LTO (#50)
 app-emulation/qemu *FLAGS-=-flto* *FLAGS+=-fno-strict-aliasing # required to compile qemu


### PR DESCRIPTION
kde-frameworks/kjsembed will fail to build otherwise. The QtUiTools:: class is MIA during linking.