### PR TITLE
sys-libs/libapparmor: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -57,6 +57,7 @@ net-p2p/cpuminer-opt *FLAGS-=-flto*
 x11-drivers/xf86-video-intel *FLAGS-=-flto*
 <app-text/mupdf-1.12.0 *FLAGS-=-flto* # Only older versions are affected
 dev-scheme/racket *FLAGS-=-flto* *FLAGS-="${IPA}" # Undefined references and multiple segfaults / violations during build.
+sys-libs/libapparmor *FLAGS-=-flto*
 sys-libs/libsepol *FLAGS-=-flto*
 sys-libs/libselinux *FLAGS-=-flto*
 sys-libs/libsemanage *FLAGS-=-flto*


### PR DESCRIPTION
Problematic when attempting to compile firejail afterwards with the ``apparmor`` USE flag.
```
x86_64-pc-linux-gnu-gcc -march=skylake -falign-functions=32 -O3 -fgraphite-identity -floop-nest-optimize -fipa-pta -fno-semantic-interposition -flto=7 -fuse-linker-plugin -pipe -Wl,-O1 -Wl,--as-needed -Wl,--hash-style=gnu -ggdb  -O2 -DVERSION='"0.9.56"'   -DPREFIX='"/usr"'  -DSYSCONFDIR='"/etc/firejail"' -DLIBDIR='"/usr/lib64"' -DHAVE_X11 -DHAVE_PRIVATE_HOME -DHAVE_APPARMOR -DHAVE_OVERLAYFS -DHAVE_SECCOMP -DHAVE_GLOBALCFG -DHAVE_SECCOMP_H -DHAVE_CHROOT -DHAVE_NETWORK -DHAVE_USERNS -DHAVE_FILE_TRANSFER -DHAVE_WHITELIST -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security   -c x11.c -o x11.o
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib64/libapparmor.so: undefined reference to `aa_query_label'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:10: firemon] Error 1
make[1]: Leaving directory '/var/tmp/portage/sys-apps/firejail-0.9.56-r1/work/firejail-0.9.56/src/firemon'
make: *** [Makefile:34: src/firemon] Error 2
make: *** Waiting for unfinished jobs....
x86_64-pc-linux-gnu-gcc  -Wl,-O1 -Wl,--as-needed -Wl,--hash-style=gnu -march=skylake -falign-functions=32 -O3 -fgraphite-identity -floop-nest-optimize -fipa-pta -fno-semantic-interposition -flto=7 -fuse-linker-plugin -pipe -pie -Wl,-z,relro -Wl,-z,now -lpthread -o firejail appimage.o appimage_size.o arp.o bandwidth.o caps.o cgroup.o checkcfg.o cmdline.o cpu.o dbus.o env.o fs.o fs_bin.o fs_dev.o fs_etc.o fs_home.o fs_hostname.o fs_lib.o fs_lib2.o fs_logger.o fs_mkdir.o fs_trace.o fs_var.o fs_whitelist.o join.o ls.o macros.o main.o mountinfo.o netfilter.o netns.o network.o network_main.o no_sandbox.o output.o paths.o preproc.o profile.o protocol.o pulseaudio.o restrict_users.o restricted_shell.o rlimit.o run_files.o run_symlink.o sandbox.o sbox.o seccomp.o shutdown.o usage.o util.o x11.o ../lib/common.o ../lib/ldd_utils.o ../lib/firejail_user.o  -lapparmor
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/../../../../lib64/libapparmor.so: undefined reference to `aa_query_label'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:10: firejail] Error 1
make[1]: Leaving directory '/var/tmp/portage/sys-apps/firejail-0.9.56-r1/work/firejail-0.9.56/src/firejail'
make: *** [Makefile:34: src/firejail] Error 2
```