### PR TITLE
x11-wm/bspwm: IPA workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -133,7 +133,6 @@ dev-lisp/clisp *FLAGS+=-falign-functions # Issue #128.  Function alignment probl
 # BEGIN: Deliberate -O3 workarounds
 www-client/firefox /-O3/-O2 # latest FF beta doesn't like -O3, forgets sessions between runs.
 www-client/torbrowser /-O3/-O2 # latest FF beta doesn't like -O3, forgets sessions between runs.  ICE on -fipa-pta.
-media-libs/x264 /-O3/-O2 # wouldn't compile otherwise on 17.0 profile running the testing branch everywhere with GCC 8.3.0
 # END: Deliberate -O3 workarounds
 
 # BEGIN: Will not build with ninja

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -133,6 +133,7 @@ dev-lisp/clisp *FLAGS+=-falign-functions # Issue #128.  Function alignment probl
 # BEGIN: Deliberate -O3 workarounds
 www-client/firefox /-O3/-O2 # latest FF beta doesn't like -O3, forgets sessions between runs.
 www-client/torbrowser /-O3/-O2 # latest FF beta doesn't like -O3, forgets sessions between runs.  ICE on -fipa-pta.
+media-libs/x264 /-O3/-O2 # wouldn't compile otherwise on 17.0 profile running the testing branch everywhere with GCC 8.3.0
 # END: Deliberate -O3 workarounds
 
 # BEGIN: Will not build with ninja
@@ -155,6 +156,7 @@ media-sound/mpc *FLAGS-="${IPA}" # hangs on exit with -fipa-pta
 dev-lang/R *FLAGS-="${IPA}" # during IPA pass: pta lto1: internal compiler error: Segmentation fault
 sys-devel/gcc *FLAGS-="${IPA}"
 dev-lisp/sbcl *FLAGS-="${IPA}" #ICE on -fipa-pta
+x11-wm/bspwm *FLAGS-="${IPA}" # needed for version 0.9.7 on 17.0 profile running the testing branch everywhere with GCC 8.3.0
 media-libs/libwebp *FLAGS-=-fipa-pta # no compilation issues, but -fipa-pta causes webp images to be displayed incorrectly
 dev-qt/qtgui *FLAGS-=-fipa-pta # Same problem as above
 # END: -fipa-pta workarounds


### PR DESCRIPTION
the latest version of bspwm wouldn't compile on my system without this workaround