### PR TITLE
dev-libs/isl: work around execv argument list too long upon linking

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -110,6 +110,7 @@ dev-lang/ocaml *FLAGS-="${GRAPHITE}"
 # END: Graphite ICE (Internal Compiler Error)
 
 #Packages which require build workarounds to be built with LTO that can be resolved directly in *FLAGS
+dev-libs/isl /-flto=*/-flto=1 # /usr/libexec/gcc/x86_64-pc-linux-gnu/X.Y.Z/collect2': execv: Argument list too long
 sys-devel/gettext *FLAGS+=-lm # needed for linker to resolve libm's log10 -- only needed for LTO
 media-libs/ilmbase *FLAGS+=-lrt # needed for linker to build media-libs/openexr with LTO
 x11-libs/wxGTK NOLDADD=1


### PR DESCRIPTION
Workaround for #264 