### PR TITLE
dev-tex/chktex: disable LTO when pcre in USE, to work around link failure

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -89,6 +89,7 @@ sci-visualization/paraview *FLAGS-=-flto*
 net-im/qtox *FLAGS-=-flto*
 app-emulation/libguestfs *FLAGS-=-flto*
 media-gfx/shotwell *FLAGS-=-flto* #Library search error with LTO enabled
+dev-tex/chktex "use pcre && FlagSubAllFlags -flto*" # Segmentation faults as libpcre doesn't get linked-in properly
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Closes #266 
