### PR TITLE
media-libs/flac: disables -O3 default -fipa-cp-clone as it breaks flac -d with LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -132,6 +132,7 @@ net-mail/mailutils "has ldap ${IUSE//+} && use ldap && FlagAdd LDFLAGS -llber" #
 dev-lisp/clisp *FLAGS+=-falign-functions # Issue #128.  Function alignment problem.
 
 # BEGIN: Deliberate -O3 workarounds
+media-libs/flac *FLAGS+=-fno-ipa-cp-clone # -fipa-cp-clone is enabled by default at -O3, breaks 'flac -d' if used in conjunction with -flto under GCC 8.3.0
 www-client/firefox /-O3/-O2 # latest FF beta doesn't like -O3, forgets sessions between runs.
 www-client/torbrowser /-O3/-O2 # latest FF beta doesn't like -O3, forgets sessions between runs.  ICE on -fipa-pta.
 # END: Deliberate -O3 workarounds


### PR DESCRIPTION
Closes #270 