### PR TITLE
add workaround for media-libs/faad2

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -134,6 +134,7 @@ net-mail/mailutils "has ldap ${IUSE//+} && use ldap && FlagAdd LDFLAGS -llber" #
 dev-lisp/clisp *FLAGS+=-falign-functions # Issue #128.  Function alignment problem.
 
 # BEGIN: Deliberate -O3 workarounds
+media-libs/faad2 *FLAGS+=-fno-tree-loop-vectorize # causes subtly wrong decoding
 www-client/firefox /-O3/-O2 # latest FF beta doesn't like -O3, forgets sessions between runs.
 www-client/torbrowser /-O3/-O2 # latest FF beta doesn't like -O3, forgets sessions between runs.  ICE on -fipa-pta.
 # END: Deliberate -O3 workarounds


### PR DESCRIPTION
this fixes off-sounding aac playback in deadbeef (from deadbeef-overlay) when faad2 is compiled with -O3