### PR TITLE
Revert "dev-libs/isl: work around execv argument list too long upon linking"

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -112,7 +112,6 @@ dev-lang/ocaml *FLAGS-="${GRAPHITE}"
 # END: Graphite ICE (Internal Compiler Error)
 
 #Packages which require build workarounds to be built with LTO that can be resolved directly in *FLAGS
-dev-libs/isl /-flto=*/-flto=1 # /usr/libexec/gcc/x86_64-pc-linux-gnu/X.Y.Z/collect2': execv: Argument list too long
 sys-devel/gettext *FLAGS+=-lm # needed for linker to resolve libm's log10 -- only needed for LTO
 media-libs/ilmbase *FLAGS+=-lrt # needed for linker to build media-libs/openexr with LTO
 x11-libs/wxGTK NOLDADD=1


### PR DESCRIPTION
Reverts InBetweenNames/gentooLTO#265

As indicated in InBetweenNames/gentooLTO#264, the workaround is no longer necessary with GCC-8.3.0-r1.