### PR TITLE
app-misc/tracker: remove seminterpos

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -178,4 +178,5 @@ dev-util/lldb *FLAGS-="-mtls-dialect=gnu2"
 sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
 sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
 net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
+app-misc/tracker *FLAGS-="${SEMINTERPOS}" # builds but makes gnome-base/nautilus deadlock
 # END: Semantic Interposition Workarounds


### PR DESCRIPTION
app-misc/tracker makes gnome-base/nautilus deadlock on start if it is compiled with ${SEMINTERPOS}.
Take a look at https://forums.gentoo.org/viewtopic-p-8324442.html and https://github.com/InBetweenNames/gentooLTO/issues/275 for more details.