### PR TITLE
[net-print/cups] Workaround seminterpos-related ICE

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -176,8 +176,9 @@ dev-util/lldb *FLAGS-="-mtls-dialect=gnu2"
 # END: TLS dialect workarounds
 
 # BEGIN: Semantic Interposition workarounds
-sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
-sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
-net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
 app-misc/tracker *FLAGS-="${SEMINTERPOS}" # builds but makes gnome-base/nautilus deadlock
+net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
+net-print/cups *FLAGS-="${SEMINTERPOS}" # ICE
+sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
+sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
 # END: Semantic Interposition Workarounds


### PR DESCRIPTION
Closes #258

Also, sorted the SEMINTERPOS section of ltoworkarounds.conf alphabetically, as a suggestion that we could apply in the rest of this file, to pursue an effort to make it more readable and easier to work with.
