### PR TITLE
app-portage/lto-rebuild: Fix bashisms in /bin/sh script

### DIFF
--- a/app-portage/lto-rebuild/files/lto-rebuild
+++ b/app-portage/lto-rebuild/files/lto-rebuild
@@ -14,9 +14,9 @@ if [ "$#" -eq 0 ] || [ "$1" = "-h" ]; then
 	echo "command will fail.  You can use -l to manually intervene."
 	echo
 	echo "Options:"
-	echo -e "-h\tDisplay this help"
-	echo -e "-l\tOnly list the packages that would be rebuilt and their slots"
-	echo -e "-r\tRebuild the packages using emerge (will ask for confirmation)"
+	printf -- "-h\tDisplay this help\n"
+	printf -- "-l\tOnly list the packages that would be rebuilt and their slots\n"
+	printf -- "-r\tRebuild the packages using emerge (will ask for confirmation)\n"
 
 else
 	if [ "$1" = "-l" ]; then

--- a/app-portage/lto-rebuild/files/lto-rebuild
+++ b/app-portage/lto-rebuild/files/lto-rebuild
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-if [ "$#" -eq 0 ] || [ "$1" == "-h" ]; then
+if [ "$#" -eq 0 ] || [ "$1" = "-h" ]; then
 
 	echo "Usage: lto-rebuild [OPTION]"
 	echo
@@ -19,9 +19,9 @@ if [ "$#" -eq 0 ] || [ "$1" == "-h" ]; then
 	echo -e "-r\tRebuild the packages using emerge (will ask for confirmation)"
 
 else
-	if [ "$1" == "-l" ]; then
+	if [ "$1" = "-l" ]; then
 		find /usr/lib /usr/lib64 -name "*.a" | xargs qfile -S -q | sort -u
-	elif [ "$1" == "-r" ]; then
+	elif [ "$1" = "-r" ]; then
 		emerge -1a $(find /usr/lib /usr/lib64 -name "*.a" | xargs qfile -S -q | sort -u)
 	else 
 		exit 1


### PR DESCRIPTION
The script which this ebuild installs has a `/bin/sh` shebang, but uses two "bashisms" which cause problems if `/bin/sh` is dash. This can be verified either by running `dev-util/checkbashisms` on the script or by attempting to use the script with dash, where the use of `==` for comparison will cause errors and `echo -e` will not behave as expected.

An alternative fix would be to change the shebang to `/bin/bash`, but this is just the sort of simple script that doesn't need any bashisms.

Note that I only replaced `echo` with `printf` where the `-e` option was used, in order to make the changes as minimal as possible while still fixing the issue, but `printf` should generally be preferred over `echo` in shell scripts due to its greater portability.