### PR TITLE
media-libs/libwebp: gcc 9 fixed runtime issues caused by fipa-pta

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -168,7 +168,6 @@ sys-devel/gcc *FLAGS-="${IPA}"
 dev-lang/gnat-gpl *FLAGS-="${IPA}"
 dev-lisp/sbcl *FLAGS-="${IPA}" #ICE on -fipa-pta
 x11-wm/bspwm *FLAGS-="${IPA}" # needed for version 0.9.7 on 17.0 profile running the testing branch everywhere with GCC 8.3.0
-media-libs/libwebp *FLAGS-=-fipa-pta # no compilation issues, but -fipa-pta causes webp images to be displayed incorrectly
 dev-qt/qtgui *FLAGS-=-fipa-pta # Same problem as above
 # END: -fipa-pta workarounds
 


### PR DESCRIPTION
Removed the workaround for this package. Is there a fixed section in the workarounds file?
