### PR TITLE
sys-apps/fakechroot: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -84,6 +84,7 @@ media-gfx/shotwell *FLAGS-=-flto* #Library search error with LTO enabled
 dev-tex/chktex "use pcre && FlagSubAllFlags -flto*" # Segmentation faults as libpcre doesn't get linked-in properly
 www-apps/hugo *FLAGS-=-flto*
 sys-libs/musl *FLAGS-=-flto*
+sys-apps/fakechroot *FLAGS-=-flto* # "Cgraph edge statement index out of range" error when linking with LTO enabled
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Fails to build otherwise, `-ffat-lto-objects` doesn't work either. I didn't try every possible combination of flags but removing `-flto*` made it build without errors.
