### PR TITLE
make.conf.lto

### DIFF
--- a/make.conf.lto
+++ b/make.conf.lto
@@ -1,0 +1,92 @@
+#This file contains the optimization defaults that GentooLTO uses
+#This includes O3, Graphite, LTO, and -fipa-pta
+#More will be added in the future.
+#Sourcing this file will enable you to transparently receive these new settings
+#without intervention.  If this is not desirable, see the file make.conf.lto.defines for custom configurations.
+
+#To use this file, first define NTHREADS to the number of threads you want the LTO
+#processes to use on your system at the top of your make.conf:
+
+#NTHREADS="12" 
+
+#A good number is the number of hardware threads you have available on your system.
+#After this, but before any other variables are defined, source this file directly:
+
+#source make.conf.lto
+
+#Then, afterwards, define your CFLAGS with your own options:
+
+#CFLAGS="-march=native ${CFLAGS} -pipe"
+
+#This enables your CFLAGS to inherit the default flags that GentooLTO uses.
+#Note that you may want to enable -falign-functions=32 if you use an Intel processor (Sandy Bridge or later).
+#See issue #164 for details.
+
+#Next, set your CXXFLAGS to CFLAGS:
+
+#CXXFLAGS="${CFLAGS}"
+
+#Your CXXFLAGS should be a superset of your CFLAGS.  Most people will never need to add anything extra to their CXXFLAGS.
+
+#Your LDFLAGS should contain *ALL* of your CFLAGS for LTO to work.  It must receieve all optimization options, march, etc.
+#package.cflags takes care of this for you--no need to manually add your {C,CXX}FLAGS here.
+#It's usually a good idea to enable -Wl,--hash-style=gnu as well to help find packages which don't respect LDFLAGS
+#Ensure that your profile's LDFLAGS are respected by including them first.
+
+#LDFLAGS="${LDFLAGS} -Wl,--hash-style=gnu"
+
+#NOTE: your profile likely contains -Wl,--as-needed and -Wl,-O1.
+#The -Wl,-01 here is a separate option sent to the linker that optimizes shared object binary sizes
+#It is NOT related to the -O option given to gcc and has no bearing on that option.
+#For example, compiling using: -fuse-linker-plugin -flto -O3 -Wl,-O1:
+#This will produce an LTO binary with -O3
+#level optimization and also pass -O1 to the linker to reduce the shared object size.
+
+#!!!Consider also using cpuid2cpuflags to set your CPU_FLAGS_* variable in your make.conf for packages that rely on explicit optimizations such as intrinsics!!!
+
+#Some quality of life things:
+
+#You may want to lower Portage's niceness level, seeing as your emerges will take longer.
+#The effectiveness of this depends on what CPU scheduler you use.
+
+#PORTAGE_NICENESS=15
+
+#LTO takes a lot more memory than non-LTO processes.  You will likely not be able to emerge many packages
+#in parallel unless you have a lot of memory available.  As an alternative, consider setting MAKEOPTS
+#to parallelize according to NTHREADS, which should avoid that problem.  You may consider balancing between
+#emerging in parallel with parallizing make as a compromise.
+
+#MAKEOPTS="-j${NTHREADS}"
+
+#Lastly, for cmake packages, you may want to set the default generator to Ninja.
+#It is considerably faster than GNU make and can help build times.
+
+#CMAKE_MAKEFILE_GENERATOR=ninja
+
+#Only one package, kde-plasma/kinfocenter, needs CMAKE_MAKEFILE_GENERATOR=emake.  It can be overridden
+#in your own package.cflags/kinfocenter.conf file like so:
+
+#kde-plasma/kinfocenter CMAKE_MAKEFILE_GENERATOR=emake
+
+#This concludes setup for GentooLTO using the default settings.
+#If you want to cherry pick these settings, source make.conf.lto.defines directly
+#and read the comments in that file.
+
+#source make.conf.lto.defines removing from there and sourcing directly in make.conf
+
+#Thanks to issue #49, no action necessary for preventing stripping of static libraries
+
+CFLAGS="-O3 ${GRAPHITE} ${SEMINTERPOS} ${FLTO} -fuse-linker-plugin"
+
+#Your LDFLAGS should contain *ALL* of your CFLAGS for LTO to work.  It must receieve all optimization options, march, etc.
+#package.cflags takes care of this for you--no need to manually add your {C,CXX}FLAGS here.
+#
+#It's usually a good idea to enable -Wl,--hash-style=gnu as well to help find packages which don't respect LDFLAGS
+#Ensure that your profile's LDFLAGS are respected by including them first.
+#LDFLAGS="${LDFLAGS} -Wl,--hash-style=gnu"
+#NOTE: your profile likely contains -Wl,--as-needed and -Wl,-O1.
+#The -Wl,-01 here is a separate option sent to the linker that optimizes shared object binary sizes
+#It is NOT related to the -O option given to gcc and has no bearing on that option.
+#For example, compiling using: -flto -O3 -Wl,-O1:
+#This will produce an LTO binary with -O3
+#level optimization and also pass -O1 to the linker to reduce the shared object size.


### PR DESCRIPTION
i would like to have removed source make.conf.lto.defines from make.conf.lto, as it cause issues with paludis package manager, and anyway makes managing simpler by sourcing both confs in make.conf directly.

Title: <category>/<package>: <description>

Ensure that any added workarounds have a comment explaining the compilation error which requires it.
Any removed workarounds should be moved to the fixed section.
If an issue exists, please link it.
See CONTRIBUTING.md for more information.
