### PR TITLE
sys-fs/btrfs-progs: disable gnu2 TLS dialect

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -172,6 +172,7 @@ dev-lang/python *FLAGS-="-mtls-dialect=gnu2"
 dev-util/lldb *FLAGS-="-mtls-dialect=gnu2"
 dev-db/firebird *FLAGS-="-mtls-dialect=gnu2"
 dev-lang/spidermonkey *FLAGS-="-mtls-dialect=gnu2"
+sys-fs/btrfs-progs *FLAGS-="-mtls-dialect=gnu2"
 # END: TLS dialect workarounds
 
 # BEGIN: Semantic Interposition workarounds


### PR DESCRIPTION
The `TLS relocation against invalid instruction` error as previously mentioned in #164 is still present.