### PR TITLE
dev-lang/python: Fixes emerge on Ofast systems

### DIFF
--- a/dev-lang/python/files/python-2.7.15-PGO.patch
+++ b/dev-lang/python/files/python-2.7.15-PGO.patch
@@ -55,7 +55,7 @@ diff -ur Python-2.7.15.orig/Makefile.pre.in Python-2.7.15/Makefile.pre.in
  run_profile_task:
  	: # FIXME: can't run for a cross build
 -	$(LLVM_PROF_FILE) $(RUNSHARED) ./$(BUILDPYTHON) $(PROFILE_TASK) || true
-+	$(LLVM_PROF_FILE) _PYTHONNOSITEPACKAGES=1 $(RUNSHARED) ./$(BUILDPYTHON) -E $(PROFILE_TASK)
++	$(LLVM_PROF_FILE) _PYTHONNOSITEPACKAGES=1 $(RUNSHARED) ./$(BUILDPYTHON) -E $(PROFILE_TASK) || true
  
  build_all_merge_profile:
  	$(LLVM_PROF_MERGER)

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -125,6 +125,10 @@ media-libs/flac *FLAGS+=-fno-ipa-cp-clone # -fipa-cp-clone is enabled by default
 media-libs/faad2 *FLAGS+=-fno-tree-loop-vectorize # causes subtly wrong decoding
 # END: Deliberate -O3 workarounds
 
+# BEGIN: -Ofast workarounds
+dev-lang/python C*FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
+# END: -Ofast workarounds
+
 # BEGIN: Will not build with ninja
 x11-misc/polybar CMAKE_MAKEFILE_GENERATOR=emake
 app-doc/doxygen CMAKE_MAKEFILE_GENERATOR=emake

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -126,7 +126,7 @@ media-libs/faad2 *FLAGS+=-fno-tree-loop-vectorize # causes subtly wrong decoding
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds
-dev-lang/python C*FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
+dev-lang/python *FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja


### PR DESCRIPTION
Added -fno-finite-math-only workaround for all python builds (fixes #326). Also fixed an issue in the build for python-2.7.15-r108 where failing instrumentation tests would cause the entire emerge to fail, which is not the case for the other python versions (fixes #200).
