### PR TITLE
dev-db/firebird: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -84,6 +84,8 @@ dev-tex/chktex "use pcre && FlagSubAllFlags -flto*" # Segmentation faults as lib
 www-apps/hugo *FLAGS-=-flto*
 sys-libs/musl *FLAGS-=-flto*
 sys-apps/fakechroot *FLAGS-=-flto* # "Cgraph edge statement index out of range" error when linking with LTO enabled
+dev-db/firebird *FLAGS=-flto*
+app-office/libreoffice "has firebird ${IUSE//+} && use firebird && FlagSubAllFlags -flto*"
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
dev-db/firebird fails to build with LTO, and app-office/libreoffice also fails if the firebird USE flag is enabled.