### PR TITLE
dev-libs/protobuf-c: doesn't compile with lto

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -86,6 +86,7 @@ sys-libs/musl *FLAGS-=-flto*
 sys-apps/fakechroot *FLAGS-=-flto* # "Cgraph edge statement index out of range" error when linking with LTO enabled
 dev-db/firebird *FLAGS=-flto*
 app-office/libreoffice "has firebird ${IUSE//+} && use firebird && FlagSubAllFlags -flto*"
+dev-libs/protobuf-c *FLAGS-=-flto*
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Build error:
It looks like it isn't passing some runtime checks after build
```/usr/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I/var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1 --c_out=. /var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1/t/test-proto3.proto                                                  
/usr/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I/var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1 --c_out=. /var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1/t/test-proto3.proto                                                  
/usr/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I/var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1 --c_out=. /var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1/t/issue220/issue220.proto                                            
/usr/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I/var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1 --c_out=. /var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1/t/issue220/issue220.proto                                            
terminate called after throwing an instance of 'std::system_error'                                                                                                                                                                                                               
  what():  Unknown error -1                                                                                                                                                                                                                                                      
/usr/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I/var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1 --c_out=. /var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1/t/issue251/issue251.proto                                            
/usr/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I/var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1 --c_out=. /var/tmp/portage/dev-libs/protobuf-c-1.3.1/work/protobuf-c-1.3.1/t/issue251/issue251.proto                                            
[libprotobuf WARNING ../../protobuf-3.7.1/src/google/protobuf/compiler/parser.cc:564] No syntax specified for the proto file: t/issue220/issue220.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)      
[libprotobuf WARNING ../../protobuf-3.7.1/src/google/protobuf/compiler/parser.cc:564] No syntax specified for the proto file: t/issue220/issue220.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)      
[libprotobuf WARNING ../../protobuf-3.7.1/src/google/protobuf/compiler/parser.cc:564] No syntax specified for the proto file: t/issue251/issue251.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)      
terminate called after throwing an instance of 'std::system_error'                                                                                                                                                                                                               
  what():  Unknown error -1                                                                                                                                                                                                                                                      
[libprotobuf WARNING ../../protobuf-3.7.1/src/google/protobuf/compiler/parser.cc:564] No syntax specified for the proto file: t/issue251/issue251.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)      
terminate called after throwing an instance of 'std::system_error'                                                                                                                                                                                                               
  what():  Unknown error -1                                                                                                                                                                                                                                                      
terminate called after throwing an instance of 'std::system_error'                                                                                                                                                                                                               
  what():  Unknown error -1                                                                                                                                                                                                                                                      
terminate called after throwing an instance of 'std::system_error'                                                                                                                                                                                                               
  what():  Unknown error -1                                                                                                                                                                                                                                                      
terminate called after throwing an instance of 'std::system_error'                                                                                                                                                                                                               
  what():  Unknown error -1                                                                                                                                                                                                                                                      
--c_out: protoc-gen-c: Plugin killed by signal 6.                                                                                                                                                                                                                                
make: *** [Makefile:2401: t/issue251/issue251.pb-c.h] Error 1                                                                                                                                                                                                                    
make: *** Waiting for unfinished jobs....                                                                                                                                                                                                                                        
--c_out: protoc-gen-c: Plugin killed by signal 6.                                                                                                                                                                                                                                
make: *** [Makefile:2397: t/test-proto3.pb-c.c] Error 1                                                                                                                                                                                                                          
--c_out: protoc-gen-c: Plugin killed by signal 6.                                                                                                                                                                                                                                
make: *** [Makefile:2397: t/test-proto3.pb-c.h] Error 1                                                                                                                                                                                                                          
--c_out: protoc-gen-c: Plugin killed by signal 6.                                                                                                                                                                                                                                
make: *** [Makefile:2399: t/issue220/issue220.pb-c.c] Error 1
--c_out: protoc-gen-c: Plugin killed by signal 6.
make: *** [Makefile:2401: t/issue251/issue251.pb-c.c] Error 1
--c_out: protoc-gen-c: Plugin killed by signal 6.
make: *** [Makefile:2399: t/issue220/issue220.pb-c.h] Error 1
```