### PR TITLE
Remove redundant -fipa-pta workarounds

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -150,17 +150,15 @@ dev-lang/gnat-gpl LTO_ENABLE_FLAGOMATIC=yes
 # BEGIN: -fipa-pta workarounds
 www-client/firefox *FLAGS-="${IPAPTA}" #ICE on -fipa-pta
 www-client/torbrowser *FLAGS-="${IPAPTA}" #ICE on -fipa-pta
-=sys-apps/gawk-4.1.4 *FLAGS-="${IPAPTA}" # during IPAPTA pass: pta lto1: internal compiler error: Segmentation fault
+=sys-apps/gawk-4.1.4 *FLAGS-="${IPAPTA}" # during IPA pass: pta lto1: internal compiler error: Segmentation fault
 dev-qt/qtwebkit *FLAGS-="${IPAPTA}"
-media-sound/mpc *FLAGS-="${IPAPTA}" # hangs on exit with -fipa-pta
-dev-lang/R *FLAGS-="${IPAPTA}" # during IPAPTA pass: pta lto1: internal compiler error: Segmentation fault
+dev-lang/R *FLAGS-="${IPAPTA}" # during IPA pass: pta lto1: internal compiler error: Segmentation fault
 sys-devel/gcc *FLAGS-="${IPAPTA}"
 dev-lang/gnat-gpl *FLAGS-="${IPAPTA}"
 dev-lisp/sbcl *FLAGS-="${IPAPTA}" #ICE on -fipa-pta
 x11-wm/bspwm *FLAGS-="${IPAPTA}" # needed for version 0.9.7 on 17.0 profile running the testing branch everywhere with GCC 8.3.0
 media-libs/libwebp *FLAGS-="${IPAPTA}" # no compilation issues, but -fipa-pta causes webp images to be displayed incorrectly
 dev-qt/qtgui *FLAGS-="${IPAPTA}" # Same problem as above
-sys-devel/gdb *FLAGS-="${IPAPTA}" # Segfault occurs when running gdb attach
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds


### PR DESCRIPTION
`media-sound/mpc` and `sys-devel/gdb` now work fine for me after #257 got fixed in GCC 9.1.

`media-libs/libwebp` appears to be ok with `-fipa-pta` too on my machine but I left that one in since the issue still might be present under some circumstances according to #308 . I can't reproduce that though, despite building with `-Ofast` myself.