### PR TITLE
Set LTO_ENABLE_FLAGOMATIC=yes for ebuilds providing USE='custom-cflags custom-optimization'

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -138,11 +138,40 @@ media-libs/musicbrainz CMAKE_MAKEFILE_GENERATOR=emake
 # END: Will not build with ninja
 
 # BEGIN: override-flagomatic workarounds
-www-client/firefox LTO_ENABLE_FLAGOMATIC=yes #The ebuild does respect your CFLAGS, it just does some messing around for enabling -flto and -O3. 
-www-client/torbrowser LTO_ENABLE_FLAGOMATIC=yes
 dev-lang/ghc LTO_ENABLE_FLAGOMATIC=yes
 sys-devel/gcc LTO_ENABLE_FLAGOMATIC=yes #Build system requires special attention, use BOOT_CFLAGS to inject flags.  Do not inject -flto, use the USE flag to do this.
 dev-lang/gnat-gpl LTO_ENABLE_FLAGOMATIC=yes
+# Ebuilds that provide their own 'custom-cflags' and/or 'custom-optimization' USE flag. You should enable those to build with your own set of flags.
+app-crypt/johntheripper LTO_ENABLE_FLAGOMATIC=yes
+app-crypt/johntheripper-jumbo LTO_ENABLE_FLAGOMATIC=yes
+app-emulation/hercules LTO_ENABLE_FLAGOMATIC=yes
+app-emulation/wine-any LTO_ENABLE_FLAGOMATIC=yes
+app-emulation/wine-d3d9 LTO_ENABLE_FLAGOMATIC=yes
+app-emulation/wine-staging LTO_ENABLE_FLAGOMATIC=yes
+app-emulation/wine-vanilla LTO_ENABLE_FLAGOMATIC=yes
+app-emulation/xen LTO_ENABLE_FLAGOMATIC=yes
+app-emulation/xen-pvgrub LTO_ENABLE_FLAGOMATIC=yes
+app-emulation/xen-tools LTO_ENABLE_FLAGOMATIC=yes
+dev-libs/klibc LTO_ENABLE_FLAGOMATIC=yes
+dev-util/electron LTO_ENABLE_FLAGOMATIC=yes
+games-emulation/zsnes LTO_ENABLE_FLAGOMATIC=yes
+media-libs/libsdl LTO_ENABLE_FLAGOMATIC=yes
+#media-libs/libsdl2 LTO_ENABLE_FLAGOMATIC=yes #USE='custom-cflags' currently masked by profile
+media-video/libav LTO_ENABLE_FLAGOMATIC=yes
+media-video/x264-encoder LTO_ENABLE_FLAGOMATIC=yes
+sci-biology/shrimp LTO_ENABLE_FLAGOMATIC=yes
+sci-biology/unafold LTO_ENABLE_FLAGOMATIC=yes
+sci-chemistry/tm-align LTO_ENABLE_FLAGOMATIC=yes
+#sys-boot/gnu-efi LTO_ENABLE_FLAGOMATIC=yes #USE='custom-cflags' currently masked by profile
+#sys-boot/refind LTO_ENABLE_FLAGOMATIC=yes #USE='custom-cflags' currently masked by profile
+sys-boot/syslinux LTO_ENABLE_FLAGOMATIC=yes
+sys-boot/tboot LTO_ENABLE_FLAGOMATIC=yes
+sys-fs/zfs LTO_ENABLE_FLAGOMATIC=yes
+sys-fs/zfs-kmod LTO_ENABLE_FLAGOMATIC=yes
+sys-kernel/spl LTO_ENABLE_FLAGOMATIC=yes
+www-client/chromium LTO_ENABLE_FLAGOMATIC=yes
+www-client/firefox LTO_ENABLE_FLAGOMATIC=yes #The ebuild does respect your CFLAGS, it just does some messing around for enabling -flto and -O3. 
+www-client/torbrowser LTO_ENABLE_FLAGOMATIC=yes
 # END: override-flagomatic workarounds
 
 #>=sys-devel/gcc-9 *FLAGS-=-flto* BOOT_CFLAGS='"${CFLAGS}"'


### PR DESCRIPTION
Since we already have an override of this kind for `www-client/firefox`, I believe it makes sense to do the same for all the other ebuilds that make use of `custom-cflags` and `custom-optimization` flags.