### PR TITLE
dev-lang/rust: Don't use -fdevirtualize-at-ltrans

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -192,6 +192,7 @@ media-video/ffmpeg *FLAGS-="-fno-plt"
 # BEGIN: -fdevirtualize-at-ltrans workarounds
 app-text/lcdf-typetools *FLAGS-="-fdevirtualize-at-ltrans" # ICE on static-var pass
 dev-python/pycryptodomex *FLAGS-="-fdevirtualize-at-ltrans" # ICE on read_cgraph_and_symbols 
+dev-lang/rust *FLAGS-="-fdevirtualize-at-ltrans" # build fails, uses clang, which doesn't accept this flag
 # END: -fdevirtualize-at-ltrans workarounds
 
 # BEGIN: GOLD linker workarounds


### PR DESCRIPTION
Building `dev-lang/rust` fails at the point in the build when it invokes clang with `-fdevirtualize-at-ltrans` and clang exits with an error because it doesn't accept this flag. Note that I am using the `system-llvm` use flag and clang 8.0.0.

Would also be nice if there were a way to automatically detect if clang is being used (perhaps by checking `CC`/`CXX`) and drop any inapplicable flags automatically. That way, users who wanted to use clang for a particular package via a package.env file wouldn't need to also filter out any inapplicable flags manually with package.cflags.