### PR TITLE
games-emulation/pcsx2: force BFD linker

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -197,6 +197,7 @@ dev-python/pycryptodomex *FLAGS-="-fdevirtualize-at-ltrans" # ICE on read_cgraph
 # BEGIN: GOLD linker workarounds
 media-libs/libcaca *FLAGS+="-fuse-ld=bfd"
 dev-util/kbuild *FLAGS+="-fuse-ld=bfd"
+games-emulation/pcsx2 *FLAGS+="-fuse-ld=bfd"
 # END: GOLD linker workarounds
 
 # BEGIN: -fno-common workarounds


### PR DESCRIPTION
If `ld.gold` is used, this package fails to build with the following error:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: CMakeFiles/USBnull-0.7.0.dir/USB.cpp.o: relocation R_386_GOTOFF against preemptible symbol _USBirqHandler cannot be used when making a shared object
collect2: error: ld returned 1 exit status
```
regardless of gcc version or `CFLAGS`. If `ld.bfd` is forced, the build is successful. Note that LTO doesn't work with gcc 9.1, but does with gcc 8.3 (see https://github.com/InBetweenNames/gentooLTO/issues/339).