### PR TITLE
dev-lang/php: Disable -fipa-pta

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -193,6 +193,7 @@ dev-qt/qtwebkit *FLAGS-="${IPAPTA}"
 dev-lang/R *FLAGS-="${IPAPTA}" # during IPA pass: pta lto1: internal compiler error: Segmentation fault
 sys-devel/gcc *FLAGS-="${IPAPTA}"
 dev-lang/gnat-gpl *FLAGS-="${IPAPTA}"
+dev-lang/php *FLAGS-="${IPAPTA}" # Segfaults when compiled with -fipa-pta
 dev-lisp/sbcl *FLAGS-="${IPAPTA}" #ICE on -fipa-pta
 x11-wm/bspwm *FLAGS-="${IPAPTA}" # needed for version 0.9.7 on 17.0 profile running the testing branch everywhere with GCC 8.3.0
 media-libs/libwebp *FLAGS-="${IPAPTA}" # no compilation issues, but -fipa-pta causes webp images to be displayed incorrectly


### PR DESCRIPTION
When compiled with the flag, PHP was causing apache to segfault under certain conditions.

Also see issue #358 for more information.