### PR TITLE
x11-wm/muffin: added workaround for -fno-semantic-interposition

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -219,6 +219,7 @@ net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
 net-print/cups *FLAGS-="${SEMINTERPOS}" # ICE
 sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
 sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
+>=x11-wm/muffin-4.0.3 *FLAGS-="${SEMINTERPOS}" # compilation fails due to maybe-uninitialized warnings and -Werror
 # END: Semantic Interposition Workarounds
 
 # BEGIN: No PLT workarounds


### PR DESCRIPTION
Added -fno-semantic-interposition workaround for `x11-wm/muffin` to fix compilation error due to maybe-uninitialized warnings and -Werror. Earlier versions of `muffin` are unaffected.
