### PR TITLE
sys-boot/systemd-boot: disable gnu2 TLS dialect

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -210,6 +210,7 @@ dev-util/lldb *FLAGS-="-mtls-dialect=gnu2"
 dev-db/firebird *FLAGS-="-mtls-dialect=gnu2"
 dev-lang/spidermonkey *FLAGS-="-mtls-dialect=gnu2"
 sys-fs/btrfs-progs *FLAGS-="-mtls-dialect=gnu2"
+sys-boot/systemd-boot *FLAGS-="-mtls-dialect=gnu2"
 # END: TLS dialect workarounds
 
 # BEGIN: Semantic Interposition workarounds


### PR DESCRIPTION
Another `TLS relocation against invalid instruction` error.