### PR TITLE
net-libs/nodejs: Added `-ffinite-math-only` workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -137,6 +137,7 @@ dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime
 >=sys-apps/coreutils-8.31 *FLAGS+='-fno-finite-math-only' # causes multiple definition of `minus_zero` error during linking
 >=sys-apps/groff-1.22.4 *FLAGS+='-fsigned-zeros' # causes conflicting declaration of `signbit` compilation error
 x11-misc/redshift *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-math-only causes a runtime error where the brightness values are interpreted incorrectly
+net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` returns error whenever it starts running
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja


### PR DESCRIPTION
Added workaround for `net-libs/nodejs`. `ffinite-math-only` (implied by `-Ofast` and `-ffast-math`) causes `npm` to fail on startup.