### PR TITLE
sys-apps/man-db: Disable LTO due to runtime issues (#403)

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -74,6 +74,7 @@ dev-lang/mono *FLAGS-=-flto*
 sys-apps/acl *FLAGS-=-flto* # Issue #209, builds fine but we cannot set any acl value using the program.
 dev-java/openjdk *FLAGS-=-flto* # Issue #204, undefined references with LTO.
 sys-apps/nix *FLAGS-=-flto* # Issue #222, LTO causes runtime failures
+sys-apps/man-db *FLAGS-=-flto* # Issue #403, LTO causes runtime failures
 sys-apps/fwupd *FLAGS-=-flto* # Issue #225, LTO causes runtime failures
 sci-visualization/paraview *FLAGS-=-flto*
 app-emulation/libguestfs *FLAGS-=-flto*


### PR DESCRIPTION
LTO disabled for sys-apps/man-db.

See #403 for more info.