### PR TITLE
dev-scheme/guile: disable -ffinite-math-only on -Ofast systems

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -141,6 +141,7 @@ dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime
 >=sys-apps/groff-1.22.4 *FLAGS+='-fsigned-zeros' # causes conflicting declaration of `signbit` compilation error
 x11-misc/redshift *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-math-only causes a runtime error where the brightness values are interpreted incorrectly
 net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` returns error whenever it starts running
+dev-scheme/guile *FLAGS+='-fno-finite-math-only' # build fails with `floating point exception`
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja


### PR DESCRIPTION
This works around `Floating point exception` error during the build.