### PR TITLE
sci-libs/tensorflow # Issue #432 tensorflow-estimator fails with missing symbol __cpu_model

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -102,6 +102,7 @@ dev-libs/libaio *FLAGS-=-flto* # Issue #314, missing symbols in LTO build compar
 sys-apps/apparmor *FLAGS-=-flto* # Issue #299, ODR violation, still builds and runs on some configurations
 media-libs/mesa *FLAGS-=-flto* # Issue #143, compiles sometimes, but exhibits runtime errors when used with LTO.  AMD and Intel drivers are known to fail. #*FLAGS-=-Wl,--as-needed # strange LTO linking bug that causes pthreads to be thrown out early under LTO (#50)
 sys-apps/sandbox *FLAGS-=-flto* # Issue #347, LTO breaks basic sandboxing functionality
+sci-libs/tensorflow *FLAGS-=-flto* # Issue #432 tensorflow-estimator fails with missing symbol __cpu_model
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with


### PR DESCRIPTION
fix for #432

