### PR TITLE
media-libs/dav1d: workaround for graphite ICE, issue #442

### DIFF
--- a/sys-config/ltoize/files/patches/media-libs/dav1d/dav1d-graphite-ice-workaround.patch
+++ b/sys-config/ltoize/files/patches/media-libs/dav1d/dav1d-graphite-ice-workaround.patch
@@ -1,0 +1,11 @@
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -22,7 +22,7 @@
+ 
+ option('enable_tests',
+     type: 'boolean',
+-    value: true,
++    value: false,
+     description: 'Build dav1d tests')
+ 
+ option('logging',


### PR DESCRIPTION
disable test to workaround #442, patch courtesy of @pchome  