### PR TITLE
app-emulation/libpod: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -14,6 +14,7 @@ sys-power/nut *FLAGS+=-ffat-lto-objects # fails during configure otherwise
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*
+app-emulation/libpod *FLAGS-=-flto*
 app-emulation/qemu *FLAGS-=-flto* *FLAGS+=-fno-strict-aliasing # required to compile qemu
 media-libs/alsa-lib *FLAGS-=-flto*
 dev-libs/elfutils *FLAGS-=-flto*


### PR DESCRIPTION
Versions 1.6.3-r2 and 1.6.4 do not play nice with LTO.

This is a golang application, so this is probably expected (its linker complained about the LTO flags)?