### PR TITLE
>=dev-lang/python-3.8: Build with fat LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -11,6 +11,7 @@ x11-terms/alacritty *FLAGS+=-ffat-lto-objects
 sys-apps/exa *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 sys-apps/bat *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 sys-power/nut *FLAGS+=-ffat-lto-objects # fails during configure otherwise
+>=dev-lang/python-3.8 *FLAGS+=-ffat-lto-objects # failes during configure, see bug #700012
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*


### PR DESCRIPTION
Will fail during configure otherwise.