### PR TITLE
Fix for Undefined symbol in x11-base/xorg-server

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -236,6 +236,7 @@ dev-libs/nss *FLAGS-="-fno-plt"
 sys-libs/glibc *FLAGS-="-fno-plt" #When using prelink, will cause a bunch of segfaults.
 media-video/ffmpeg *FLAGS-="-fno-plt"
 app-emulation/wine-staging *FLAGS-="-fno-plt"
+app-emulation/wine-vanilla *FLAGS-="-fno-plt"
 dev-db/mysql-connector-c *FLAGS-="-fno-plt" # SIGABRT during compile if not used
 sys-libs/compiler-rt-sanitizers *FLAGS-="-fno-plt"
 x11-base/xorg-server *FLAGS-="-fno-plt" # Undefined symbol in i956 driver

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -238,6 +238,7 @@ media-video/ffmpeg *FLAGS-="-fno-plt"
 app-emulation/wine-staging *FLAGS-="-fno-plt"
 dev-db/mysql-connector-c *FLAGS-="-fno-plt" # SIGABRT during compile if not used
 sys-libs/compiler-rt-sanitizers *FLAGS-="-fno-plt"
+x11-base/xorg-server *FLAGS-="-fno-plt" # Undefined symbol in i956 driver
 # END: No PLT workarounds
 
 # BEGIN: -fdevirtualize-at-ltrans workarounds


### PR DESCRIPTION
This change fixes this error:
Failed to load /usr/lib64/xorg/modules/drivers/modesetting_drv.so: /usr/lib64/xorg/modules/drivers/modesetting_drv.so: undefined symbol: glamor_block_handler
When trying to start x11-base/xorg-server-1.20.7 with an i965 video card.
