### PR TITLE
Gcc needs to be compiled with graphite in USE

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The biggest gotcha with `-O3` is that it does not play nice at all with Undefine
 
 ## How to use this configuration
 
-Add the `mv` overlay (`layman -a mv`) and then add this overlay (`layman -a lto-overlay`) to your system and run `emerge sys-config/ltoize`. Add the package to your `/etc/portage/package.accept_keywords` if necessary. This will add the necessary overrides to `/etc/portage/`, but it won't modify your `make.conf`. It will create a `make.conf.lto` symlink in `/etc/portage` with the default GentooLTO configuration. You may need to add `graphite` to your `USE` and recompile `gcc` before adding the GentooLTO configuration to your `make.conf` file. To use the default configuration, define a variable `NTHREADS` with the number of threads you want to use for LTO. Then, source the file in your own `make.conf` like in this example:
+Add the `mv` overlay (`layman -a mv`) and then add this overlay (`layman -a lto-overlay`) to your system and run `emerge sys-config/ltoize`. Add the package to your `/etc/portage/package.accept_keywords` if necessary. This will add the necessary overrides to `/etc/portage/`, but it won't modify your `make.conf`. It will create a `make.conf.lto` symlink in `/etc/portage` with the default GentooLTO configuration. You may need to add `graphite` to your USE flags and recompile GCC before adding the GentooLTO configuration to your `make.conf` file. To use the default configuration, define a variable `NTHREADS` with the number of threads you want to use for LTO. Then, source the file in your own `make.conf` like in this example:
 
 ~~~ bash
 NTHREADS="12"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The biggest gotcha with `-O3` is that it does not play nice at all with Undefine
 
 ## How to use this configuration
 
-Add the `mv` overlay (`layman -a mv`) and then add this overlay (`layman -a lto-overlay`) to your system and run `emerge sys-config/ltoize`. Add the package to your `/etc/portage/package.accept_keywords` if necessary. This will add the necessary overrides to `/etc/portage/`, but it won't modify your `make.conf`. It will create a `make.conf.lto` symlink in `/etc/portage` with the default GentooLTO configuration. To use the default configuration, define a variable `NTHREADS` with the number of threads you want to use for LTO. Then, source the file in your own `make.conf` like in this example:
+Add the `mv` overlay (`layman -a mv`) and then add this overlay (`layman -a lto-overlay`) to your system and run `emerge sys-config/ltoize`. Add the package to your `/etc/portage/package.accept_keywords` if necessary. This will add the necessary overrides to `/etc/portage/`, but it won't modify your `make.conf`. It will create a `make.conf.lto` symlink in `/etc/portage` with the default GentooLTO configuration. You may need to add `graphite` to your `USE` and recompile `gcc` before adding the GentooLTO configuration to your `make.conf` file. To use the default configuration, define a variable `NTHREADS` with the number of threads you want to use for LTO. Then, source the file in your own `make.conf` like in this example:
 
 ~~~ bash
 NTHREADS="12"


### PR DESCRIPTION
It took me forever to figure out why gcc could not find isl even after installing different versions and recompiling gcc. I found by looking through solved issues that gcc needs to be compiled with graphite in the USE. Maybe it's obvious to more experienced people but I felt that something should be added specifying that this needs to be done since the error makes you go down the tree of thinking the issue is with isl. Feel free to reject this, I'm pretty new to Gentoo so I don't know what things people need to be told or not. It could also maybe be made a bit more obvious that there is a chat group. I didn't notice the glitter badge for quite a while. I guess I was just not observant enough so it's probably not needed.

Either way, now that I have this working, I am excited to try it out! I do a lot of networking and am considering witching some of my Linux routers to Gentoo so I will be able to test various networking packages which are probably rather obscure.