### PR TITLE
sci-misc/boinc: build without lto

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -107,6 +107,7 @@ sys-apps/apparmor *FLAGS-=-flto* # Issue #299, ODR violation, still builds and r
 media-libs/mesa *FLAGS-=-flto* # Issue #143, compiles sometimes, but exhibits runtime errors when used with LTO.  AMD and Intel drivers are known to fail. #*FLAGS-=-Wl,--as-needed # strange LTO linking bug that causes pthreads to be thrown out early under LTO (#50)
 sys-apps/sandbox *FLAGS-=-flto* # Issue #347, LTO breaks basic sandboxing functionality
 sci-libs/tensorflow *FLAGS-=-flto* # Issue #432 tensorflow-estimator fails with missing symbol __cpu_model
+sci-misc/boinc *FLAGS-=-flto* # buffer overflow when starting boinc_client
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with


### PR DESCRIPTION
boinc_client crashes on startup due to a buffer overflow when built with -flto. Building with fat lto objects did not help on my machine. Other flags (graphite, no sem interpos, ipa, devirt) seem fine.
