### PR TITLE
LibreOffice only needs the semantic interposition workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -86,7 +86,6 @@ www-apps/hugo *FLAGS-=-flto*
 sys-libs/musl *FLAGS-=-flto*
 sys-apps/fakechroot *FLAGS-=-flto* # "Cgraph edge statement index out of range" error when linking with LTO enabled
 dev-db/firebird *FLAGS=-flto*
-app-office/libreoffice "has firebird ${IUSE//+} && use firebird && FlagSubAllFlags -flto*"
 net-misc/nx *FLAGS-=-flto* # ODR violation during compilation
 x11-base/xorg-server *FLAGS-=-flto* # linking error during compilation
 sys-cluster/glusterfs *FLAGS=-flto* # undefined reference to `glfs_subvol_done'
@@ -230,6 +229,7 @@ net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
 net-print/cups *FLAGS-="${SEMINTERPOS}" # ICE
 sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
 sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
+app-office/libreoffice *FLAGS-="${SEMINTERPOS}"
 # END: Semantic Interposition Workarounds
 
 # BEGIN: No PLT workarounds


### PR DESCRIPTION
Title: app-office/libreoffice: libreoffice can be compiled with lto with the semantic interposition workaround