### PR TITLE
dev-python/numpy: Added `-ffinite-math-only` workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -140,7 +140,7 @@ kde-frameworks/kactivities-stats /-O3/-O2 # causes systemsettings5 to crash
 dev-lang/python *FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
 <media-libs/opus-1.3.1-r1 /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 kde-frameworks/kjs /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
-dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python
+dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' *FLAGS-='-ffinite-math-only' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python; '-ffinite-math-only' causes incorrect runtime handling of infinite values
 net-analyzer/rrdtool *FLAGS+='-fno-finite-math-only' # configure fails due to non-compliant IEEE arithmetic
 dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime errors cause installation of R library tools to fail during emerge
 >=sys-apps/coreutils-8.31 *FLAGS+='-fno-finite-math-only' # causes multiple definition of `minus_zero` error during linking


### PR DESCRIPTION
Added `-ffinite-math-only` workaround for `dev-python/numpy`, which fixes #470.
