### PR TITLE
Changes for sys-libs/libapparmor and media-sound/musescore

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -108,6 +108,7 @@ media-libs/mesa *FLAGS-=-flto* # Issue #143, compiles sometimes, but exhibits ru
 sys-apps/sandbox *FLAGS-=-flto* # Issue #347, LTO breaks basic sandboxing functionality
 sci-libs/tensorflow *FLAGS-=-flto* # Issue #432 tensorflow-estimator fails with missing symbol __cpu_model
 sci-misc/boinc *FLAGS-=-flto* # buffer overflow when starting boinc_client
+sys-libs/libapparmor *FLAGS-=-flto* # Undefined symbol error when trying to compile sys-apps/apparmor
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -130,7 +130,6 @@ sys-power/thermald *FLAGS+=-Wl,--no-fatal-warnings *FLAGS+=-Wno-error
 #dev-lang/php "export EXTRA_ECONF=--disable-gcc-global-regs" # or dev-lang/php *FLAGS+="-flto-partition=max" for < 7.2 # https://bugs.php.net/bug.php?id=72702 # Worse performance than otherwise #109
 net-mail/mailutils "has ldap ${IUSE//+} && use ldap && FlagAdd LDFLAGS -llber" #With LTO, this dependency must be linked in explicitly to resolve undefined reference errors "ber_memvfree" and so on
 dev-lisp/clisp *FLAGS+=-falign-functions # Issue #128.  Function alignment problem.
-media-sound/musescore *FLAGS-="-Wl,*" # Fails with any Wl flags
 
 # BEGIN: Deliberate -O3 workarounds
 media-libs/flac *FLAGS+=-fno-ipa-cp-clone # -fipa-cp-clone is enabled by default at -O3, breaks 'flac -d' if used in conjunction with -flto under GCC 8.3.0

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -130,6 +130,7 @@ sys-power/thermald *FLAGS+=-Wl,--no-fatal-warnings *FLAGS+=-Wno-error
 #dev-lang/php "export EXTRA_ECONF=--disable-gcc-global-regs" # or dev-lang/php *FLAGS+="-flto-partition=max" for < 7.2 # https://bugs.php.net/bug.php?id=72702 # Worse performance than otherwise #109
 net-mail/mailutils "has ldap ${IUSE//+} && use ldap && FlagAdd LDFLAGS -llber" #With LTO, this dependency must be linked in explicitly to resolve undefined reference errors "ber_memvfree" and so on
 dev-lisp/clisp *FLAGS+=-falign-functions # Issue #128.  Function alignment problem.
+media-sound/musescore *FLAGS-="-Wl,*" # Fails with any Wl flags
 
 # BEGIN: Deliberate -O3 workarounds
 media-libs/flac *FLAGS+=-fno-ipa-cp-clone # -fipa-cp-clone is enabled by default at -O3, breaks 'flac -d' if used in conjunction with -flto under GCC 8.3.0


### PR DESCRIPTION
Musescore does not compile at all. Libapparmor compiles, but causes undefined symbol errors when compiling sys-apps/apparmor

I forgot to save the build logs, I can reemerge these packages and submit them if needed