### PR TITLE
media-video/aegisub: add workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -120,6 +120,7 @@ sys-libs/libapparmor *FLAGS-=-flto* # Undefined symbol error when trying to comp
 sys-devel/gettext *FLAGS+=-lm # needed for linker to resolve libm's log10 -- only needed for LTO
 media-libs/ilmbase *FLAGS+=-lrt # needed for linker to build media-libs/openexr with LTO
 x11-libs/wxGTK NOLDADD=1 C*FLAGS-="-Wl,*" # Issue #40, does not build when -Wl linker flags are passed to the compiler through C*FLAGS
+media-video/aegisub NOLDADD=1 C*FLAGS-="-Wl,*" # does not build when -Wl linker flags are passed to the compiler through C*FLAGS
 #dev-qt/qtcore "export EXTRA_CXXFLAGS='${CXXFLAGS}' EXTRA_LFLAGS='${LDFLAGS}'" #work around overwritten flags (#32)
 sys-libs/ncurses *FLAGS-=-Wl,--as-needed *FLAGS+=-ldl # checking whether able to link to dl*() functions... configure: error: Cannot link test program for libdl (#111)
 sys-libs/ncurses-compat *FLAGS-=-Wl,--as-needed *FLAGS+=-ldl # checking whether able to link to dl*() functions... configure: error: Cannot link test program for libdl (#111)


### PR DESCRIPTION
Doesn't build with '-Wl,-O1' in CFLAGS
```
/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../lib64/Scrt1.o: in function `_start':
(.text+0x20): undefined reference to `main'
collect2: error: ld returned 1 exit status
```