### PR TITLE
sci-visualization/paraview: Change CFLAGS

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -78,7 +78,6 @@ dev-java/openjdk *FLAGS-=-flto* # Issue #204, undefined references with LTO.
 sys-apps/nix *FLAGS-=-flto* # Issue #222, LTO causes runtime failures
 sys-apps/man-db *FLAGS-=-flto* # Issue #403, LTO causes runtime failures
 sys-apps/fwupd *FLAGS-=-flto* # Issue #225, LTO causes runtime failures
-sci-visualization/paraview *FLAGS-=-flto*
 app-emulation/libguestfs *FLAGS-=-flto*
 media-gfx/shotwell *FLAGS-=-flto* #Library search error with LTO enabled
 dev-tex/chktex "use pcre && FlagSubAllFlags -flto*" # Segmentation faults as libpcre doesn't get linked-in properly
@@ -118,6 +117,7 @@ dev-libs/libbsd *FLAGS-=-flto* # Undefined symbol error when building mail-clien
 # BEGIN: Graphite ICE (Internal Compiler Error)
 # Report them to GCC team
 # END: Graphite ICE (Internal Compiler Error)
+sci-visualization/paraview *FLAGS-="${GRAPHITE}"
 
 #Packages which require build workarounds to be built with LTO that can be resolved directly in *FLAGS
 sys-devel/gettext *FLAGS+=-lm # needed for linker to resolve libm's log10 -- only needed for LTO

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -117,7 +117,7 @@ dev-libs/libbsd *FLAGS-=-flto* # Undefined symbol error when building mail-clien
 # BEGIN: Graphite ICE (Internal Compiler Error)
 # Report them to GCC team
 # END: Graphite ICE (Internal Compiler Error)
-sci-visualization/paraview *FLAGS-="${GRAPHITE}"
+sci-visualization/paraview *FLAGS-="${GRAPHITE}" # Removing Graphite optimizations allows build to complete with sane memory usage for --jobs > 1
 
 #Packages which require build workarounds to be built with LTO that can be resolved directly in *FLAGS
 sys-devel/gettext *FLAGS+=-lm # needed for linker to resolve libm's log10 -- only needed for LTO


### PR DESCRIPTION
I was attempting to build the newest available paraview (5.8.0-r2 on gentoo's default repo) and was constantly running out of memory during the build. At around 91% of the way through my RAM and swap (32 GB + 40 GB) would be maxed out (-j16). Changing to -j2 still would not fix the issue. I did not have the patience for -j1.
So after enabling all the [debugging recommendations](https://github.com/InBetweenNames/gentooLTO/wiki/Debugging#workflow-for-debugging-a-build-failure) and disabling them one-by-one, starting with `*FLAGS-=-flto*`, then `/-O3/-O2` etc., the build could finish with the graphite flags disabled. I didn't go further to remove individual `${GRAPHITE}` flags (i.e. at the time of writing was `GRAPHITE="-fgraphite-identity -floop-nest-optimize"`). If someone has any insight in to the memory effects of either of these flags then let's please discuss it.