### PR TITLE
sys-fabric/libibverbs: don't build with LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -91,6 +91,7 @@ x11-base/xorg-server *FLAGS-=-flto* # linking error during compilation
 sys-cluster/glusterfs *FLAGS-=-flto* # undefined reference to `glfs_subvol_done'
 sys-cluster/ceph *FLAGS-=-flto*  # linking error during compilation
 mail-filter/procmail *FLAGS-=-flto* # Causes compile to hang indefinitely
+sys-fabric/libibverbs *FLAGS-=-flto* # Issue #506, Undefined references
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Fixes #506
