### PR TITLE
dev-python/pillow: added `-fno-finite-math-only` workaround.

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -148,6 +148,7 @@ dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime
 x11-misc/redshift *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-math-only causes a runtime error where the brightness values are interpreted incorrectly
 net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` returns error whenever it starts running
 dev-scheme/guile *FLAGS+='-fno-finite-math-only' # build fails with `floating point exception`
+dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `import matplotlib.pyplot` to fail with `undefined symbol: __log_finite`
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja


### PR DESCRIPTION
Although it compiles fine without the workaround, it causes `import matplotlib.pyplot` to fail with `undefined symbol: __log_finite`.
