### PR TITLE
sys-devel/llvm: added `-fno-finite-math-only` workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -158,7 +158,7 @@ x11-misc/redshift *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-m
 net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` returns error whenever it starts running
 dev-scheme/guile *FLAGS+='-fno-finite-math-only' # build fails with `floating point exception`
 dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `import matplotlib.pyplot` to fail with `undefined symbol: __log_finite`
->=sys-devel/llvm-10.0.0 *FLAGS+='-fno-finite-math-only' # compiles fine but causes clang to fail to emerge with `undefined reference to __log10_finite`
+>=sys-devel/llvm-10.0.0 *FLAGS+='-fno-finite-math-only' # compiles fine but causes clang to fail to emerge with ``undefined reference to `__log10_finite'``
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -158,6 +158,7 @@ x11-misc/redshift *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-m
 net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` returns error whenever it starts running
 dev-scheme/guile *FLAGS+='-fno-finite-math-only' # build fails with `floating point exception`
 dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `import matplotlib.pyplot` to fail with `undefined symbol: __log_finite`
+>=sys-devel/llvm-10.0.0 *FLAGS+='-fno-finite-math-only' # compiles fine but causes clang to fail to emerge with `undefined reference to __log10_finite`
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja


### PR DESCRIPTION
Without the workaround, llvm would compile fine, but clang-10 would fail to emerge with error ``undefined reference to `__log10_finite'``. I wasn't able to reproduce this with the llvm/clang-9 toolchain on my machine. This seems to be a new error though, since I was previously able to emerge the llvm/clang-10 toolchain without errors. Perhaps this is due to a newer gcc/glibc?
