### PR TITLE
Some Ofast and mtls-dialect=gnu2 workarounds

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -148,6 +148,7 @@ mail-filter/procmail /-O3/-O2 # Causes compile to hang indefinitely
 # BEGIN: -Ofast workarounds
 dev-lang/python *FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
 <media-libs/opus-1.3.1-r1 /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
+media-sound/mumble /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the libopus source throws an error if ffast-math is enabled
 kde-frameworks/kjs /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' *FLAGS-='-ffinite-math-only' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python; '-ffinite-math-only' causes incorrect runtime handling of infinite values
 net-analyzer/rrdtool *FLAGS+='-fno-finite-math-only' # configure fails due to non-compliant IEEE arithmetic

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -229,6 +229,7 @@ dev-lang/ocaml *FLAGS-="${IPAPTA}" # ICE during IPA pass: pta in lto1: Segmentat
 
 # BEGIN: TLS dialect workarounds
 www-client/firefox *FLAGS-="-mtls-dialect=gnu2"
+www-client/torbrowser *FLAGS-="-mtls-dialect=gnu2"
 sys-fs/eudev *FLAGS-="-mtls-dialect=gnu2"
 sys-libs/glibc *FLAGS-="-mtls-dialect=gnu2"
 dev-lang/mono *FLAGS-="-mtls-dialect=gnu2"

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -239,6 +239,7 @@ dev-db/firebird *FLAGS-="-mtls-dialect=gnu2"
 dev-lang/spidermonkey *FLAGS-="-mtls-dialect=gnu2"
 sys-fs/btrfs-progs *FLAGS-="-mtls-dialect=gnu2"
 sys-boot/systemd-boot *FLAGS-="-mtls-dialect=gnu2"
+net-libs/libtorrent-rasterbar *FLAGS-="-mtls-dialect=gnu2" # causes memory corruption at runtime
 # END: TLS dialect workarounds
 
 # BEGIN: Semantic Interposition workarounds

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -152,6 +152,7 @@ media-sound/mumble /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_M
 kde-frameworks/kjs /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 >=sys-libs/glibc-2.30 /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' *FLAGS-='-ffinite-math-only' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python; '-ffinite-math-only' causes incorrect runtime handling of infinite values
+media-video/mpv /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # causes incorrect behavior (black screen) when enabling interpolation or downscaling
 net-analyzer/rrdtool *FLAGS+='-fno-finite-math-only' # configure fails due to non-compliant IEEE arithmetic
 dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime errors cause installation of R library tools to fail during emerge
 >=sys-apps/coreutils-8.31 *FLAGS+='-fno-finite-math-only' # causes multiple definition of `minus_zero` error during linking

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -150,6 +150,7 @@ dev-lang/python *FLAGS+='-fno-finite-math-only' # instrumentation tests hang/seg
 <media-libs/opus-1.3.1-r1 /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 media-sound/mumble /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the libopus source throws an error if ffast-math is enabled
 kde-frameworks/kjs /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
+>=sys-libs/glibc-2.30 /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' *FLAGS-='-ffinite-math-only' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python; '-ffinite-math-only' causes incorrect runtime handling of infinite values
 net-analyzer/rrdtool *FLAGS+='-fno-finite-math-only' # configure fails due to non-compliant IEEE arithmetic
 dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime errors cause installation of R library tools to fail during emerge


### PR DESCRIPTION
5 workarounds, included are:

media-video/mpv: disable ffast-math, a black screen was occurring when using the mitchell downscaler, or when using interpolation
sys-libs/glibc: disable ffast-math, same reason as opus (the preprocessor throws an error if ffast-math is enabled)
media-sound/mumble: disable ffast-math, same reason as opus (libopus is included as a bundled dependency)
net-libs/libtorrent-rasterbar: disable mtls-dialect=gnu2, this was causing memory corruption
www-client/torbrowser: disable mtls-dialect=gnu2, this one makes torbrowser and firefox workarounds consistent