### PR TITLE
Testworkarounds

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -118,6 +118,7 @@ dev-lang/ruby *FLAGS-=-flto* # Test failure
 dev-libs/libpcre *FLAGS-=-flto* # Test failure
 net-misc/networkmanager *FLAGS-=-flto* # Test failure
 sys-fs/cryfs *FLAGS-=-flto* # Test failure
+app-crypt/gcr *FLAGS-=-flto* # Test failure
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -228,6 +228,7 @@ dev-db/mongodb *FLAGS-="${IPAPTA}" # ICE with -fipa-pta
 dev-lang/ocaml *FLAGS-="${IPAPTA}" # ICE during IPA pass: pta in lto1: Segmentation fault
 dev-python/libvirt-python *FLAGS-="${IPAPTA}" # Test failure
 dev-db/postgresql *FLAGS-="${IPAPTA}" # Test failure
+dev-libs/protobuf *FLAGS-="${IPAPTA}" # Test failure
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -11,6 +11,7 @@ x11-terms/alacritty *FLAGS+=-ffat-lto-objects
 sys-apps/exa *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 sys-apps/bat *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 sys-power/nut *FLAGS+=-ffat-lto-objects # fails during configure otherwise
+media-libs/libvpx *FLAGS+=-ffat-lto-objects # Test failure
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -250,6 +250,7 @@ net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
 net-print/cups *FLAGS-="${SEMINTERPOS}" # ICE
 sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
 sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
+app-emulation/libvirt *FLAGS-="${SEMINTERPOS}" # Test failure
 # END: Semantic Interposition Workarounds
 
 # BEGIN: No PLT workarounds

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -367,4 +367,5 @@ x11-wm/i3 *FLAGS-="${NOCOMMON}"
 media-sound/bluez-alsa *FLAGS-="${NOCOMMON}"
 # END: -fno-common workarounds
 
+dev-lang/ruby *FLAGS+=-fno-strict-aliasing # No build or runtime failures, but recommended by the package to avoid incorrect optimizations
 #sys-devel/prelink EGIT_BRANCH="master_staging"

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -225,6 +225,7 @@ dev-qt/qtgui *FLAGS-="${IPAPTA}" # Same problem as above
 dev-db/mongodb *FLAGS-="${IPAPTA}" # ICE with -fipa-pta
 dev-lang/ocaml *FLAGS-="${IPAPTA}" # ICE during IPA pass: pta in lto1: Segmentation fault
 dev-python/libvirt-python *FLAGS-="${IPAPTA}" # Test failure
+dev-db/postgresql *FLAGS-="${IPAPTA}" # Test failure
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -115,6 +115,7 @@ sys-libs/libapparmor *FLAGS-=-flto* # Undefined symbol error when trying to comp
 dev-libs/libbsd *FLAGS-=-flto* # Undefined symbol error when building mail-client/mailx
 sys-libs/libxcrypt *FLAGS-=-flto* # Undefined symbols in library files cause dependencies like net-misc/whois to fail to build
 dev-lang/ruby *FLAGS-=-flto* # Test failure
+dev-libs/libpcre *FLAGS-=-flto* # Test failure
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -114,6 +114,7 @@ sci-misc/boinc *FLAGS-=-flto* # buffer overflow when starting boinc_client
 sys-libs/libapparmor *FLAGS-=-flto* # Undefined symbol error when trying to compile sys-apps/apparmor
 dev-libs/libbsd *FLAGS-=-flto* # Undefined symbol error when building mail-client/mailx
 sys-libs/libxcrypt *FLAGS-=-flto* # Undefined symbols in library files cause dependencies like net-misc/whois to fail to build
+dev-lang/ruby *FLAGS-=-flto* # Test failure
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -116,6 +116,7 @@ dev-libs/libbsd *FLAGS-=-flto* # Undefined symbol error when building mail-clien
 sys-libs/libxcrypt *FLAGS-=-flto* # Undefined symbols in library files cause dependencies like net-misc/whois to fail to build
 dev-lang/ruby *FLAGS-=-flto* # Test failure
 dev-libs/libpcre *FLAGS-=-flto* # Test failure
+net-misc/networkmanager *FLAGS-=-flto* # Test failure
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -117,6 +117,7 @@ sys-libs/libxcrypt *FLAGS-=-flto* # Undefined symbols in library files cause dep
 dev-lang/ruby *FLAGS-=-flto* # Test failure
 dev-libs/libpcre *FLAGS-=-flto* # Test failure
 net-misc/networkmanager *FLAGS-=-flto* # Test failure
+sys-fs/cryfs *FLAGS-=-flto* # Test failure
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -381,4 +381,5 @@ media-sound/bluez-alsa *FLAGS-="${NOCOMMON}"
 # END: -fno-common workarounds
 
 dev-lang/ruby *FLAGS+=-fno-strict-aliasing # No build or runtime failures, but recommended by the package to avoid incorrect optimizations
+sys-libs/compiler-rt-sanitizers *FLAGS+=-Wno-unused-command-line-argument # Test failure
 #sys-devel/prelink EGIT_BRANCH="master_staging"

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -234,6 +234,7 @@ dev-python/libvirt-python *FLAGS-="${IPAPTA}" # Test failure
 dev-db/postgresql *FLAGS-="${IPAPTA}" # Test failure
 dev-libs/protobuf *FLAGS-="${IPAPTA}" # Test failure
 media-video/ffmpeg *FLAGS-="${IPAPTA}" # Test failure
+sys-devel/clang *FLAGS-="${IPAPTA}" # Test failure
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -231,6 +231,7 @@ dev-lang/ocaml *FLAGS-="${IPAPTA}" # ICE during IPA pass: pta in lto1: Segmentat
 dev-python/libvirt-python *FLAGS-="${IPAPTA}" # Test failure
 dev-db/postgresql *FLAGS-="${IPAPTA}" # Test failure
 dev-libs/protobuf *FLAGS-="${IPAPTA}" # Test failure
+media-video/ffmpeg *FLAGS-="${IPAPTA}" # Test failure
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -150,6 +150,7 @@ media-libs/faad2 *FLAGS+=-fno-tree-loop-vectorize # causes subtly wrong decoding
 kde-frameworks/kactivities-stats /-O3/-O2 # causes systemsettings5 to crash
 mail-filter/procmail /-O3/-O2 # Causes compile to hang indefinitely
 media-libs/lcms /-O3/-O2 # Test failure
+sci-libs/scotch /-O3/-O2 # Test failure
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -148,6 +148,7 @@ media-libs/flac *FLAGS+=-fno-ipa-cp-clone # -fipa-cp-clone is enabled by default
 media-libs/faad2 *FLAGS+=-fno-tree-loop-vectorize # causes subtly wrong decoding
 kde-frameworks/kactivities-stats /-O3/-O2 # causes systemsettings5 to crash
 mail-filter/procmail /-O3/-O2 # Causes compile to hang indefinitely
+media-libs/lcms /-O3/-O2 # Test failure
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -224,6 +224,7 @@ media-libs/libwebp *FLAGS-="${IPAPTA}" # no compilation issues, but -fipa-pta ca
 dev-qt/qtgui *FLAGS-="${IPAPTA}" # Same problem as above
 dev-db/mongodb *FLAGS-="${IPAPTA}" # ICE with -fipa-pta
 dev-lang/ocaml *FLAGS-="${IPAPTA}" # ICE during IPA pass: pta in lto1: Segmentation fault
+dev-python/libvirt-python *FLAGS-="${IPAPTA}" # Test failure
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds


### PR DESCRIPTION
These tests were done on a x86_64 glibc system.
Note that app-emulation/libvirt failed with those changes regardless, due to sandbox issues at a later point. All others passed tests with these changes