### PR TITLE
net-misc/dhcp fix fatal runtime failure

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -151,6 +151,7 @@ kde-frameworks/kactivities-stats /-O3/-O2 # causes systemsettings5 to crash
 mail-filter/procmail /-O3/-O2 # Causes compile to hang indefinitely
 media-libs/lcms /-O3/-O2 # Test failure
 sci-libs/scotch /-O3/-O2 # Test failure
+net-misc/dhcp /-O3/-O2 # Runtime failure, DHCPDISCOVER doesn't work correctly - introduced with gcc 10?
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds


### PR DESCRIPTION
dhclient (at least when dispatched by networkmanager) would send broken DHCPDISCOVERs , rendering it useless