### PR TITLE
cross-{i686,x86_64}-w64-mingw32/mingw64-runtime: disable "-flto" for causing linking errors

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -94,6 +94,8 @@ sys-cluster/ceph *FLAGS-=-flto*  # linking error during compilation
 mail-filter/procmail *FLAGS-=-flto* # Causes compile to hang indefinitely
 sys-fabric/libibverbs *FLAGS-=-flto* # Issue #506, Undefined references
 app-office/gnucash *FLAGS-=-flto* # error: type ‘struct _iterate’ violates the C++ One Definition Rule [-Werror=odr]
+cross-i686-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
+cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
See: https://github.com/TheGreatMcPain/TheGreatMcPain-overlay/issues/1

`-flto` applied to mingw64-runtime results in errors linking errors during the compilation of `cross-{i686,x86_64}-w64-mingw32/gcc` such as:

```
libtool: link: /usr/libexec/gcc/i686-w64-mingw32/ranlib .libs/libgfortran.a
libtool: link: rm -fr .libs/libgfortran.lax .libs/libgfortran.lax
libtool: link: ( cd ".libs" && rm -f "libgfortran.la" && ln -s "../libgfortran.la" "libgfortran.la" )
make[3]: Leaving directory '/var/tmp/portage/cross-i686-w64-mingw32/gcc-9.3.0/work/build/i686-w64-mingw32/libgfortran'
make[2]: Leaving directory '/var/tmp/portage/cross-i686-w64-mingw32/gcc-9.3.0/work/build/i686-w64-mingw32/libgfortran'
make[1]: Leaving directory '/var/tmp/portage/cross-i686-w64-mingw32/gcc-9.3.0/work/build'
make: *** [Makefile:953: all] Error 2
```
```
crt/pesect.c:18:25: warning: type of '_image_base__' does not match original declaration [-Wlto-type-mismatch]
crt/pseudo-reloc.c:50:13: note: type 'char' should match type 'struct IMAGE_DOS_HEADER'
crt/pseudo-reloc.c:50:13: note: '_image_base__' was previously declared here
/usr/libexec/gcc/i686-w64-mingw32/ld: /var/tmp/portage/cross-i686-w64-mingw32/gcc-9.3.0/temp/libstdc++-6.dll.9B4CEJ.ltrans0.ltrans.o:<artificial>:(.text+0x9c07): undefined reference to `strnlen'
/usr/libexec/gcc/i686-w64-mingw32/ld: /var/tmp/portage/cross-i686-w64-mingw32/gcc-9.3.0/temp/libstdc++-6.dll.9B4CEJ.ltrans0.ltrans.o:<artificial>:(.text+0x9d51): undefined reference to `strnlen'
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:696: libstdc++.la] Error 1
```