### PR TITLE
disable LTO on dev-scheme/gambit

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -96,7 +96,6 @@ sys-fabric/libibverbs *FLAGS-=-flto* # Issue #506, Undefined references
 app-office/gnucash *FLAGS-=-flto* # error: type ‘struct _iterate’ violates the C++ One Definition Rule [-Werror=odr]
 cross-i686-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
-dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults
@@ -123,6 +122,7 @@ dev-libs/libpcre *FLAGS-=-flto* # Test failure
 net-misc/networkmanager *FLAGS-=-flto* # Test failure
 sys-fs/cryfs *FLAGS-=-flto* # Test failure
 app-crypt/gcr *FLAGS-=-flto* # Test failure
+dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -96,6 +96,7 @@ sys-fabric/libibverbs *FLAGS-=-flto* # Issue #506, Undefined references
 app-office/gnucash *FLAGS-=-flto* # error: type ‘struct _iterate’ violates the C++ One Definition Rule [-Werror=odr]
 cross-i686-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
+dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Gambit is a dialect of scheme that compiles scheme code to C, and calls GCC to compile it to object files or binaries. 

The error occurs at runtime. When `gsc` is built with `-flto=*` or `-ffat-lto-objects` on GCC version 9 and above, `gsc` appears to pass object files to `ld` without escaping, which causes shell expansion and build failures. E.g.
```
... compile /home/user/git/gerbil/bootstrap/lib/gerbil/core$_MOP_$_MOP_1___rt.scm
x86_64-pc-linux-gnu-gcc: error: /tmp/core/usr/bin/x86_64-pc-linux-gnu-gccMOP_/usr/bin/x86_64-pc-linux-gnu-gccMOP_1___rt.o1.xaubLa.ltrans0.o: No such file or directory
x86_64-pc-linux-gnu-gcc: warning: ‘-x lto’ after last input file has no effect
x86_64-pc-linux-gnu-gcc: fatal error: no input files
```

Where `$_` gets expanded to `/usr/bin/x86_64-pc-linux-gnu-gcc`

`gsc` has no trouble with `-O3`, `-fipa-pta`, `-fno-semantic-interposition` or other optimization flags (it seems). 

PR to override `-flto` on `dev-scheme/gambit`. Thanks for reviewing!