### PR TITLE
dev-libs/intel-neo: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -96,6 +96,7 @@ sys-fabric/libibverbs *FLAGS-=-flto* # Issue #506, Undefined references
 app-office/gnucash *FLAGS-=-flto* # error: type ‘struct _iterate’ violates the C++ One Definition Rule [-Werror=odr]
 cross-i686-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
+dev-libs/intel-neo *FLAGS-=-flto* # error: violates the C++ One Definition Rule [-Werror=odr]
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Build dev-libs/intel-neo with LTO caused ODR violations error

```
../compute-runtime-20.16.16582/shared/source/os_interface/linux/drm_allocation.h:14:8: error: type 'struct OsHandle' violates the C++ One Definition Rule [-Werror=odr]
   14 | struct OsHandle {
      |        ^
../compute-runtime-20.16.16582/opencl/source/memory_manager/os_agnostic_memory_manager.cpp:43:8: note: a different type is defined in another translation unit
   43 | struct OsHandle {
      |        ^
../compute-runtime-20.16.16582/shared/source/os_interface/linux/drm_allocation.h:15:19: note: the first difference of corresponding definitions is field 'bo'
   15 |     BufferObject *bo = nullptr;
      |                   ^
../compute-runtime-20.16.16582/opencl/source/memory_manager/os_agnostic_memory_manager.cpp:43:8: note: a type with different number of fields is defined in another translation unit
   43 | struct OsHandle {
      |        ^
../compute-runtime-20.16.16582/opencl/source/command_stream/create_command_stream_impl.cpp:18:40: error: 'commandStreamReceiverFactory' violates the C++ One Definition Rule [-Werror=odr]
   18 | extern CommandStreamReceiverCreateFunc commandStreamReceiverFactory[IGFX_MAX_CORE];
      |                                        ^
../compute-runtime-20.16.16582/shared/source/command_stream/command_stream_receiver.cpp:33:33: note: array types have different bounds
   33 | CommandStreamReceiverCreateFunc commandStreamReceiverFactory[2 * IGFX_MAX_CORE] = {};
      |                                 ^
../compute-runtime-20.16.16582/shared/source/gen9/command_stream_receiver_hw_gen9.cpp:28:44: error: 'commandStreamReceiverFactory' violates the C++ One Definition Rule [-Werror=odr]
   28 |     extern CommandStreamReceiverCreateFunc commandStreamReceiverFactory[IGFX_MAX_CORE];
      |                                            ^
../compute-runtime-20.16.16582/shared/source/command_stream/command_stream_receiver.cpp:33:33: note: array types have different bounds
   33 | CommandStreamReceiverCreateFunc commandStreamReceiverFactory[2 * IGFX_MAX_CORE] = {};
      |                                 ^
../compute-runtime-20.16.16582/shared/source/command_stream/command_stream_receiver.cpp:33:33: note: 'commandStreamReceiverFactory' was previously declared here
lto1: all warnings being treated as errors
lto-wrapper: fatal error: /usr/bin/g++ returned 1 exit status
compilation terminated.
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```


