### PR TITLE
app-portage/lto-rebuild: add arm64 keyword

### DIFF
--- a/app-portage/lto-rebuild/lto-rebuild-0.9.8.ebuild
+++ b/app-portage/lto-rebuild/lto-rebuild-0.9.8.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="https://github.com/InBetweenNames/gentooLTO"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="


### PR DESCRIPTION
lto-rebuild works fine on arm64, so adding ~arm64 to avoid ~* and ** in
arm64 users keyword file.

Title: app-portage/lto-rebuild: add arm64 keyword

lto-rebuild works fine on arm64, so adding ~arm64 to avoid ~* and ** in
