### PR TITLE
Suggest NTHREADS="auto" in documentation and samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The biggest gotcha with `-O3` is that it does not play nice at all with Undefine
 Add the `mv` overlay (`layman -a mv`) and then add this overlay (`layman -a lto-overlay`) to your system and run `emerge sys-config/ltoize`. Add the package to your `/etc/portage/package.accept_keywords` if necessary. This will add the necessary overrides to `/etc/portage/`, but it won't modify your `make.conf`. It will create a `make.conf.lto` symlink in `/etc/portage` with the default GentooLTO configuration. To use the default configuration, define a variable `NTHREADS` with the number of threads you want to use for LTO. Then, source the file in your own `make.conf` like in this example:
 
 ~~~ bash
+#Set this to "auto" to have gcc determine optimal number of cores (GCC 10+)
 NTHREADS="12"
 
 source make.conf.lto

--- a/sys-config/ltoize/files/make.conf.lto
+++ b/sys-config/ltoize/files/make.conf.lto
@@ -9,6 +9,7 @@
 #NTHREADS="12" 
 
 #A good number is the number of hardware threads you have available on your system.
+#You may also set this to "auto" to have gcc determine optimal number of cores (GCC 10+) 
 #After this, but before any other variables are defined, source this file directly:
 
 #source make.conf.lto

--- a/sys-config/ltoize/files/make.conf.lto.defines
+++ b/sys-config/ltoize/files/make.conf.lto.defines
@@ -20,6 +20,7 @@
 
 #FLTO is of the form -flto[=n] where n is the number of threads to use during linking.
 #It's usually a good idea to set this to the number of hardware threads in your system
+#You may also set this to "auto" to have gcc determine optimal number of cores (GCC 10+)
 FLTO="-flto=${NTHREADS}"
 
 #GRAPHITE contains Graphite specific optimizations and other optimizations that are disabled at O3


### PR DESCRIPTION
GCC 10 and higher support -flto=auto, allowing for gcc to determine
optimal number of cores to use. If -flto is set to a number, and certain
projects such as llvm are build, it will multiply this number by number
of make instances, causing too many processes to be created, ultimately
slowing down the build to a crawl on smaller devices with less ram(or
causing OOM conditions). This commit suggests using auto in configs for
ltoize and README.md.

Title: sys-config/ltoize: Suggest NTHREADS="auto" in documentation and samples
Closes #565 
Closes #527 
