### PR TITLE
Re-enable LTO for Mesa

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -111,7 +111,6 @@ dev-libs/protobuf *FLAGS-=-flto* #Upstream bug https://github.com/protocolbuffer
 >=sys-apps/attr-2.4.48 *FLAGS-=-flto* # Issue #268, causes segfaults all over the system
 dev-libs/libaio *FLAGS-=-flto* # Issue #314, missing symbols in LTO build compared to non-LTO build, leads to problems with sys-fs/lvm2
 sys-apps/apparmor *FLAGS-=-flto* # Issue #299, ODR violation, still builds and runs on some configurations
-media-libs/mesa *FLAGS-=-flto* # Issue #143, compiles sometimes, but exhibits runtime errors when used with LTO.  AMD and Intel drivers are known to fail. #*FLAGS-=-Wl,--as-needed # strange LTO linking bug that causes pthreads to be thrown out early under LTO (#50)
 sys-apps/sandbox *FLAGS-=-flto* # Issue #347, LTO breaks basic sandboxing functionality
 sci-libs/tensorflow *FLAGS-=-flto* # Issue #432 tensorflow-estimator fails with missing symbol __cpu_model
 sci-misc/boinc *FLAGS-=-flto* # buffer overflow when starting boinc_client


### PR DESCRIPTION
As per https://github.com/InBetweenNames/gentooLTO/issues/143 Mesa could now be safely compiled with LTO and that’s in fact a default for some other distros, like Arch.