### PR TITLE
ltoworkarounds: remove a fdevirtualize-at-ltrans workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -285,7 +285,6 @@ x11-base/xorg-server *FLAGS-="-fno-plt" # Undefined symbol in i956 driver
 
 # BEGIN: -fdevirtualize-at-ltrans workarounds
 app-text/lcdf-typetools *FLAGS-="-fdevirtualize-at-ltrans" # ICE on static-var pass
-dev-python/pycryptodomex *FLAGS-="-fdevirtualize-at-ltrans" # ICE on read_cgraph_and_symbols
 # END: -fdevirtualize-at-ltrans workarounds
 
 # BEGIN: GOLD linker workarounds


### PR DESCRIPTION
Cannot reproduce ICE