### PR TITLE
dev-util/radare2: *FLAGS-=-flto* (ICE)

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -97,6 +97,7 @@ app-office/gnucash *FLAGS-=-flto* # error: type ‘struct _iterate’ violates t
 cross-i686-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 dev-libs/intel-neo *FLAGS-=-flto* # error: violates the C++ One Definition Rule [-Werror=odr]
+dev-util/radare2 *FLAGS-=-flto* # ICE in IPA pass
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
```
during IPA pass: cp
lto1: internal compiler error: Segmentation fault
```

Tested flags with just `-flto`, gcc 10.2.0