### PR TITLE
sys-config/ltoize: Made the warn message more understandable

### DIFF
--- a/sys-config/ltoize/ltoize-0.9.2.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.2.ebuild
@@ -37,9 +37,9 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 8.2.0; then
-		ewarn "Warning: Active GCC version < 8.2.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '8.2.0', it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
-			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die
 		else
 			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"

--- a/sys-config/ltoize/ltoize-0.9.3-r1.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.3-r1.ebuild
@@ -36,9 +36,9 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 9.1.0; then
-		ewarn "Warning: Active GCC version < 9.1.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '9.1.0', it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
-			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die
 		else
 			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"

--- a/sys-config/ltoize/ltoize-0.9.3-r2.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.3-r2.ebuild
@@ -36,9 +36,9 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 9.1.0; then
-		ewarn "Warning: Active GCC version < 9.1.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '9.1.0', it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
-			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die
 		else
 			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"

--- a/sys-config/ltoize/ltoize-0.9.3.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.3.ebuild
@@ -37,9 +37,9 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 9.1.0; then
-		ewarn "Warning: Active GCC version < 9.1.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '9.1.0', it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
-			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die
 		else
 			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"

--- a/sys-config/ltoize/ltoize-0.9.4-r1.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.4-r1.ebuild
@@ -35,9 +35,9 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 9.2.0; then
-		ewarn "Warning: Active GCC version < 9.2.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '9.2.0', it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
-			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die
 		else
 			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"

--- a/sys-config/ltoize/ltoize-0.9.4.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.4.ebuild
@@ -35,9 +35,9 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 9.1.0; then
-		ewarn "Warning: Active GCC version < 9.1.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '9.1.0', it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
-			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die
 		else
 			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"

--- a/sys-config/ltoize/ltoize-0.9.6.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.6.ebuild
@@ -38,9 +38,9 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 10.1.0; then
-		ewarn "Warning: Active GCC version < 10.1.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '10.1.0', it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
-			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die
 		else
 			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"

--- a/sys-config/ltoize/ltoize-0.9.7.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.7.ebuild
@@ -38,9 +38,9 @@ pkg_setup() {
 	ACTIVE_GCC=$(gcc-fullversion)
 
 	if ver_test "${ACTIVE_GCC}" -lt 10.2.0; then
-		ewarn "Warning: Active GCC version < 10.2.0, it is recommended that you use the newest GCC if you want LTO."
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '10.2.0', it is recommended that you use the newest GCC if you want LTO."
 		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
-			eerror "Aborting LTOize installation due to older GCC -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
 			die
 		else
 			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"


### PR DESCRIPTION
**Title:** sys-config/ltoize: Made the warn message more understandable

Community member (@uniminin) asked me for help with with this ebuild that was failing because he had version 9.3.0 installed where i believe that the current method could be confusing for some users thus reasoning for this merge request.

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>
