### PR TITLE
workaround: net-libs/libiscsi fails to compile with -fno-semantic-interposition

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -266,6 +266,7 @@ app-misc/tracker *FLAGS-="${SEMINTERPOS}" # builds but makes gnome-base/nautilus
 dev-lang/swi-prolog *FLAGS-="${SEMINTERPOS}" # segfaults during build
 media-sound/ardour *FLAGS-="${SEMINTERPOS}" # ICE in record_target_from_binfo during GIMPLE pass
 net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
+net-libs/libiscsi *FLAGS-="${SEMINTERPOS}"
 net-print/cups *FLAGS-="${SEMINTERPOS}" # ICE
 sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
 sys-libs/glibc *FLAGS-="${SEMINTERPOS}"


### PR DESCRIPTION
error: inlining failed in call to ‘always_inline’ ‘read.localalias’: function not inlinable

Compiles with workaround