### PR TITLE
Disable LTO for mesa on i965

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -124,6 +124,7 @@ net-misc/networkmanager *FLAGS-=-flto* # Test failure
 sys-fs/cryfs *FLAGS-=-flto* # Test failure
 app-crypt/gcr *FLAGS-=-flto* # Test failure
 dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
+media-libs/mesa "has video_cards_i965 ${IUSE//+} && use video_cards_i965 && FlagSubAllFlags -flto*"
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with


### PR DESCRIPTION
Fixes https://github.com/InBetweenNames/gentooLTO/issues/577
