### PR TITLE
app-crypt/tpm2-tss: Added workaround for -fno-semantic-interposition

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -263,6 +263,7 @@ net-libs/libtorrent-rasterbar *FLAGS-="-mtls-dialect=gnu2" # causes memory corru
 # END: TLS dialect workarounds
 
 # BEGIN: Semantic Interposition workarounds
+app-crypt/tpm2-tss *FLAGS-="${SEMINTERPOS}" # Problem with inlining, see issue #592
 app-misc/tracker *FLAGS-="${SEMINTERPOS}" # builds but makes gnome-base/nautilus deadlock
 dev-lang/swi-prolog *FLAGS-="${SEMINTERPOS}" # segfaults during build
 media-sound/ardour *FLAGS-="${SEMINTERPOS}" # ICE in record_target_from_binfo during GIMPLE pass


### PR DESCRIPTION
Closes gentooLTO/issues/#592

Without it when compiling an impossible optimization breaks the process

```src/tss2-fapi/ifapi_helpers.c: In function ‘ifapi_asprintf’:
/usr/include/bits/stdio2.h:213:1: error: inlining failed in call to ‘always_inline’ ‘vasprintf.localalias’: function not inlinable
  213 | __NTH (vasprintf (char **__restrict __ptr, const char *__restrict __fmt,
      | ^~~~~```
