### PR TITLE
Update lto.patch for x264 (need to use x264-9999)

### DIFF
--- a/sys-config/ltoize/files/patches/media-libs/x264/lto.patch
+++ b/sys-config/ltoize/files/patches/media-libs/x264/lto.patch
@@ -1,11 +1,12 @@
---- a/configure	2017-10-12 23:56:01.941756673 +0300
-+++ b/configure	2017-10-12 23:56:57.781761873 +0300
-@@ -962,7 +962,7 @@
+/var/lib/layman/lto-overlay/sys-config/ltoize/files/patches/media-libs/x264 # cat lto.patch 
+--- a/configure 2020-07-07 20:37:00.103200843 -0400
++++ b/configure 2020-07-07 20:36:38.819867863 -0400
+@@ -1017,7 +1017,7 @@
  CPU_ENDIAN="little-endian"
  if [ $compiler = GNU ]; then
      echo "int i[2] = {0x42494745,0}; double f[2] = {0x1.0656e6469616ep+102,0};" > conftest.c
 -    $CC $CFLAGS conftest.c -c -o conftest.o 2>/dev/null || die "endian test failed"
-+    $CC $CFLAGS conftest.c -o conftest.o -shared 2>/dev/null || die "endian test failed"
-     if (${cross_prefix}strings -a conftest.o | grep -q BIGE) && (${cross_prefix}strings -a conftest.o | grep -q FPendian) ; then
++    $CC $CFLAGS conftest.c -c -o conftest.o -shared 2>/dev/null || die "endian test failed"
+     if (${STRINGS} -a conftest.o | grep -q BIGE) && (${STRINGS} -a conftest.o | grep -q FPendian) ; then
          define WORDS_BIGENDIAN
          CPU_ENDIAN="big-endian"


### PR DESCRIPTION
From #538 Thanks @Cognomines!

Title: media-libs/x264

This fixes the patch error with x264, but you have to use x264-9999 for it to work.