### PR TITLE
cross-arm-none-eabi/newlib: Disable lto

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -96,6 +96,7 @@ sys-fabric/libibverbs *FLAGS-=-flto* # Issue #506, Undefined references
 app-office/gnucash *FLAGS-=-flto* # error: type ‘struct _iterate’ violates the C++ One Definition Rule [-Werror=odr]
 cross-i686-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
+cross-arm-none-eabi/newlib *FLAGS-=-flto* # Causes 'arm-none-eabi-gcc' to segfault
 dev-libs/intel-neo *FLAGS-=-flto* # error: violates the C++ One Definition Rule [-Werror=odr]
 dev-util/radare2 *FLAGS-=-flto* # ICE in IPA pass
 


### PR DESCRIPTION
If `newlib` is compiled with LTO enabled `arm-none-eabi-gcc` will crash when compiling a project that was generated by STM32CubeMX.

`make` log: [newlib-lto-segfault.log](https://github.com/InBetweenNames/gentooLTO/files/5241255/newlib-lto-segfault.log)

I think the important bit from the log is this:
```
during IPA pass: materialize-all-clones
In function '_exit':
lto1: internal compiler error: Segmentation fault
0x7efd4bf1baaf ???
	/usr/src/debug/sys-libs/glibc-2.32-r1/glibc-2.32/signal/../sysdeps/unix/sysv/linux/x86_64/sigaction.c:0
0x7efd4bf88263 ???
	../sysdeps/x86_64/multiarch/../strchr.S:32
0x7efd4bf039c9 __libc_start_main
	../csu/libc-start.c:314
Please submit a full bug report,
with preprocessed source if appropriate.
Please include the complete backtrace with any bug report.
See <https://bugs.gentoo.org/> for instructions.
lto-wrapper: fatal error: arm-none-eabi-gcc returned 1 exit status
compilation terminated.
/usr/libexec/gcc/arm-none-eabi/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
make: *** [Makefile:166: build/Blinky.elf] Error 1
```

Disabling LTO for `newlib` fixes this.