### PR TITLE
dev-libs/rocr-runtime: Build without LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -99,6 +99,7 @@ cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-arm-none-eabi/newlib *FLAGS-=-flto* # Causes 'arm-none-eabi-gcc' to segfault
 dev-libs/intel-neo *FLAGS-=-flto* # error: violates the C++ One Definition Rule [-Werror=odr]
 dev-util/radare2 *FLAGS-=-flto* # ICE in IPA pass
+dev-libs/rocr-runtime *FLAGS-=-flto* # Causes segfaults
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Building dev-libs/rocr-runtime will cause tools like rocminfo or clinfo (and presumably many others) to segfault.
Disabling LTO completely fixes the issue (when built with fat lto objects the issue still persists).