### PR TITLE
dev-lang/spidermonkey: Workaround for ICE during ipa-pta pass

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -242,6 +242,7 @@ media-libs/libwebp *FLAGS-="${IPAPTA}" # no compilation issues, but -fipa-pta ca
 dev-qt/qtgui *FLAGS-="${IPAPTA}" # Same problem as above
 dev-db/mongodb *FLAGS-="${IPAPTA}" # ICE with -fipa-pta
 dev-lang/ocaml *FLAGS-="${IPAPTA}" # ICE during IPA pass: pta in lto1: Segmentation fault
+=dev-lang/spidermonkey-78.3.1 *FLAGS-="${IPAPTA}" # ICE during IPA pass: pta in lto1: Segmentation fault
 dev-python/libvirt-python *FLAGS-="${IPAPTA}" # Test failure
 dev-db/postgresql *FLAGS-="${IPAPTA}" # Test failure
 dev-libs/protobuf *FLAGS-="${IPAPTA}" # Test failure


### PR DESCRIPTION
Compiling Spidermonkey 78.3.1 with ${IPAPTA} flags results in the following error:

`during IPA pass: pta
lto1: internal compiler error: Segmentation fault`

Removing it using ltoworkarounds.conf solves the issue.