### PR TITLE
>=dev-lang/spidermonkey-78.3.1 Disable fipa-pta, segfault during build

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -249,6 +249,7 @@ media-video/ffmpeg *FLAGS-="${IPAPTA}" # Test failure
 sys-devel/clang *FLAGS-="${IPAPTA}" # Test failure
 net-p2p/monero *FLAGS-="${IPAPTA}" # ICE with -fipa-pta
 mail-client/thunderbird *FLAGS-="${IPAPTA}" # ICE with GCC 10.2.0 (seen with thunderbird 68.12.0)
+>=dev-lang/spidermonkey-78.3.1 *FLAGS-="${IPAPTA}" # Segfault during build with GCC 10.2.0
 # END: -fipa-pta workarounds
 
 # BEGIN: TLS dialect workarounds


### PR DESCRIPTION
The 78.3.1 ebuild now enables LTO with the lto use flag