### PR TITLE
sys-libs/libomp: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -99,6 +99,7 @@ cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-arm-none-eabi/newlib *FLAGS-=-flto* # Causes 'arm-none-eabi-gcc' to segfault
 dev-libs/intel-neo *FLAGS-=-flto* # error: violates the C++ One Definition Rule [-Werror=odr]
 dev-util/radare2 *FLAGS-=-flto* # ICE in IPA pass
+sys-libs/libomp *FLAGS-=-flto* # ODR violation during compilation
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Building `sys-libs/libompt` with LTO caused One Definition Rule Violation Error

log:
```
 2414 | typedef struct KMP_ALIGN_CACHE kmp_base_info {
      |                                ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2414:32: note: a different type is defined in another translation unit
 2414 | typedef struct KMP_ALIGN_CACHE kmp_base_info {
      |                                ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2448:26: note: the first difference of corresponding definitions is field ‘th_def_allocator’
 2448 |   omp_allocator_handle_t th_def_allocator; /* default allocator */
      |                          ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2448:26: note: a field of same name but different type is defined in another translation unit
 2448 |   omp_allocator_handle_t th_def_allocator; /* default allocator */
      |                          ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2414:32: note: type ‘void *’ should match type ‘omp_allocator_handle_t’
 2414 | typedef struct KMP_ALIGN_CACHE kmp_base_info {
      |                                ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2554:31: warning: type ‘union kmp_info’ violates the C++ One Definition Rule [-Wodr]
 2554 | typedef union KMP_ALIGN_CACHE kmp_info {
      |                               ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2554:31: note: a different type is defined in another translation unit
 2554 | typedef union KMP_ALIGN_CACHE kmp_info {
      |                               ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2557:19: note: the first difference of corresponding definitions is field ‘th’
 2557 |   kmp_base_info_t th;
      |                   ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2557:19: note: a field of same name but different type is defined in another translation unit
 2557 |   kmp_base_info_t th;
      |                   ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2554:31: note: type ‘struct kmp_base_info_t’ itself violates the C++ One Definition Rule
 2554 | typedef union KMP_ALIGN_CACHE kmp_info {
      |                               ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2597:32: warning: type ‘struct kmp_base_team’ violates the C++ One Definition Rule [-Wodr]
 2597 | typedef struct KMP_ALIGN_CACHE kmp_base_team {
      |                                ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2597:32: note: a different type is defined in another translation unit
 2597 | typedef struct KMP_ALIGN_CACHE kmp_base_team {
      |                                ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2666:26: note: the first difference of corresponding definitions is field ‘t_def_allocator’
 2666 |   omp_allocator_handle_t t_def_allocator; /* default allocator */
      |                          ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2666:26: note: a field of same name but different type is defined in another translation unit
 2666 |   omp_allocator_handle_t t_def_allocator; /* default allocator */
      |                          ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2597:32: note: type ‘omp_allocator_handle_t’ should match type ‘void *’
 2597 | typedef struct KMP_ALIGN_CACHE kmp_base_team {
      |                                ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2691:23: warning: type ‘union kmp_team’ violates the C++ One Definition Rule [-Wodr]
 2691 | union KMP_ALIGN_CACHE kmp_team {
      |                       ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2691:23: note: a different type is defined in another translation unit
 2691 | union KMP_ALIGN_CACHE kmp_team {
      |                       ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2692:19: note: the first difference of corresponding definitions is field ‘t’
 2692 |   kmp_base_team_t t;
      |                   ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2692:19: note: a field of same name but different type is defined in another translation unit
 2692 |   kmp_base_team_t t;
      |                   ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:2691:23: note: type ‘struct kmp_base_team_t’ itself violates the C++ One Definition Rule
 2691 | union KMP_ALIGN_CACHE kmp_team {
      |                       ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:957:13: warning: type of ‘__kmpc_free’ does not match original declaration [-Wlto-type-mismatch]
  957 | extern void __kmpc_free(int gtid, void *ptr, omp_allocator_handle_t al);
      |             ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_alloc.cpp:1578:6: note: type mismatch in parameter 3
 1578 | void __kmpc_free(int gtid, void *ptr, const omp_allocator_handle_t allocator) {
      |      ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_alloc.cpp:1578:6: note: type ‘void *’ should match type ‘omp_allocator_handle_t’
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_alloc.cpp:1578:6: note: ‘__kmpc_free’ was previously declared here
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_alloc.cpp:1578:6: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:956:14: warning: type of ‘__kmpc_alloc’ does not match original declaration [-Wlto-type-mismatch]
  956 | extern void *__kmpc_alloc(int gtid, size_t sz, omp_allocator_handle_t al);
      |              ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_alloc.cpp:1444:7: note: type mismatch in parameter 3
 1444 | void *__kmpc_alloc(int gtid, size_t size, omp_allocator_handle_t allocator) {
      |       ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_alloc.cpp:1444:7: note: type ‘void *’ should match type ‘omp_allocator_handle_t’
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_alloc.cpp:1444:7: note: ‘__kmpc_alloc’ was previously declared here
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_alloc.cpp:1444:7: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:3020:21: warning: ‘__kmp_threads’ violates the C++ One Definition Rule [-Wodr]
 3020 | extern kmp_info_t **__kmp_threads; /* Descriptors for the threads */
      |                     ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_global.cpp:418:14: note: type ‘union kmp_info_t’ itself violates the C++ One Definition Rule
  418 | kmp_info_t **__kmp_threads = NULL;
      |              ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp.h:3020:21: warning: ‘__kmp_threads’ violates the C++ One Definition Rule [-Wodr]
 3020 | extern kmp_info_t **__kmp_threads; /* Descriptors for the threads */
      |                     ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_global.cpp:418:14: note: type ‘union kmp_info_t’ itself violates the C++ One Definition Rule
  418 | kmp_info_t **__kmp_threads = NULL;
      |              ^
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_global.cpp:418:14: note: ‘__kmp_threads’ was previously declared here
/var/tmp/portage/sys-libs/libomp-11.0.0/work/openmp/runtime/src/kmp_global.cpp:418:14: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
{standard input}: Assembler messages:
{standard input}: Error: invalid attempt to declare external version name as default in symbol `GOMP_atomic_end@@VERSION'
lto-wrapper: fatal error: /usr/bin/gcc returned 1 exit status
compilation terminated.
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```
