### PR TITLE
Fix segfault when starting libvirtd

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -242,6 +242,7 @@ media-libs/libwebp *FLAGS-="${IPAPTA}" # no compilation issues, but -fipa-pta ca
 dev-qt/qtgui *FLAGS-="${IPAPTA}" # Same problem as above
 dev-db/mongodb *FLAGS-="${IPAPTA}" # ICE with -fipa-pta
 dev-lang/ocaml *FLAGS-="${IPAPTA}" # ICE during IPA pass: pta in lto1: Segmentation fault
+app-emulation/libvirt *FLAGS-="${IPAPTA}" # Segmentation fault when starting libvirtd
 dev-python/libvirt-python *FLAGS-="${IPAPTA}" # Test failure
 dev-db/postgresql *FLAGS-="${IPAPTA}" # Test failure
 dev-libs/protobuf *FLAGS-="${IPAPTA}" # Test failure


### PR DESCRIPTION
Add libvirt in the -fipa-pta workarounds to fix a segfault when starting libvirt daemon.

Without this fix:
```
$ gdb libvirtd                                      
(gdb) run
Starting program: /usr/sbin/libvirtd
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7c06530 in virLogOutputListFree () from /usr/lib64/libvirt.so.0
```

With this fix: libvirtd starts normally.