### PR TITLE
net-misc/nextcloud-client: Fixes segfault by turning off LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -99,6 +99,7 @@ cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-arm-none-eabi/newlib *FLAGS-=-flto* # Causes 'arm-none-eabi-gcc' to segfault
 dev-libs/intel-neo *FLAGS-=-flto* # error: violates the C++ One Definition Rule [-Werror=odr]
 dev-util/radare2 *FLAGS-=-flto* # ICE in IPA pass
+net-misc/nextcloud-client *FLAGS-="-flto"* # Segfaults at start with libQt5Core.so
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Desactivate LTO for nextcloud-client to fix a segfault at start.

Without this fix:
```
Thread 1 "nextcloud" received signal SIGSEGV, Segmentation fault.
0x00007fffeec6f861 in ?? () from /usr/lib64/libQt5Core.so.5
```

With this fix: `nextcloud` starts normally.

