### PR TITLE
dev-util/sccache: Fails to link without -ffat-lto-objects

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -13,6 +13,7 @@ sys-apps/bat *FLAGS+=-ffat-lto-objects # fails to link against git2 functions
 sys-power/nut *FLAGS+=-ffat-lto-objects # fails during configure otherwise
 media-libs/libvpx *FLAGS+=-ffat-lto-objects # Test failure
 net-libs/quiche *FLAGS+=-ffat-lto-objects # relocation R_X86_64_PC32 against undefined hidden symbol `GFp_ia32cap_P' can not be used when making a shared object
+dev-util/sccache *FLAGS+=-ffat-lto-objects # fails to link
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*


### PR DESCRIPTION
Similar to other rust programs, `sccache` needs `-ffat-lto-objects` to build.