### PR TITLE
app-admin/keepassxc: disable lto, otherwise segfaults on start

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -31,7 +31,7 @@ dev-db/mariadb *FLAGS-=-flto*
 sci-libs/arrayfire *FLAGS-=-flto*
 dev-lang/perl *FLAGS-=-flto*
 net-misc/dhcp "has server ${IUSE//+} && use server && FlagSubAllFlags -flto*" # Cannot be built with LTO by default, but can if "server" USE is disabled
-app-admin/keepassxc "has autotype ${IUSE//+} && use autotype && FlagSubAllFlags -flto*" # Cannot be built with LTO if using autotype
+app-admin/keepassxc *FLAGS-=-flto* # segfaults on start since Qt 5.15.1
 sys-devel/gdb *FLAGS-=-flto*
 dev-lang/spidermonkey *FLAGS-=-flto*
 net-wireless/aircrack-ng *FLAGS-=-flto*


### PR DESCRIPTION
Disable lto entirely, otherwise it segfaults on start since Qt 5.15.1

Fixes issue:
https://github.com/InBetweenNames/gentooLTO/issues/622