### PR TITLE
dev-libs/gjs: Disabled LTO because of runtime errors

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -107,7 +107,6 @@ sys-libs/libomp *FLAGS-=-flto* # Issue #619 libomp-11.0.0_rc4 fails to build wit
 sys-devel/llvm FLAGS-=-flto* # Issue #619 temporarily disabled for now due to build errors
 sys-devel/clang FLAGS-=-flto* # Issue #619 Same as above
 sys-libs/libomp FLAGS-=-flto* # Issue #619 Same as above
->=dev-libs/gjs-1.66.1 *FLAGS-=-flto* # generates general protection fault when starting up gnome
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults
@@ -136,6 +135,7 @@ app-crypt/gcr *FLAGS-=-flto* # Test failure
 dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
 media-libs/mesa "has video_cards_i965 ${IUSE//+} && use video_cards_i965 && FlagSubAllFlags -flto*"
 dev-libs/rocr-runtime *FLAGS-=-flto* # Causes crashes in multiple OpenCL tools
+>=dev-libs/gjs-1.66.1 *FLAGS-=-flto* # generates general protection fault when starting up gnome
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -107,6 +107,7 @@ sys-libs/libomp *FLAGS-=-flto* # Issue #619 libomp-11.0.0_rc4 fails to build wit
 sys-devel/llvm FLAGS-=-flto* # Issue #619 temporarily disabled for now due to build errors
 sys-devel/clang FLAGS-=-flto* # Issue #619 Same as above
 sys-libs/libomp FLAGS-=-flto* # Issue #619 Same as above
+>=dev-libs/gjs-1.66.1 *FLAGS-=-flto* # generates general protection fault when starting up gnome
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
When compiled with lto, gjs produces general protection faults when gdm starts up.

```
Nov 11 13:21:47 terra kernel: traps: gnome-shell[2631] general protection fault ip:7ff8ee6c03b0 sp:7ffc03d827d0 error:0 in libgjs.so.0.0.0[7ff8ee68d000+82000]                                                     
Nov 11 13:21:47 terra systemd[1]: Started Process Core Dump (PID 2681/UID 0).                                                                                                                                      
Nov 11 13:21:47 terra systemd-coredump[2682]: [🡕] Process 2631 (gnome-shell) of user 997 dumped core.                                                                                                              
Nov 11 13:21:47 terra systemd[1]: systemd-coredump@4-2681-0.service: Succeeded.                                                                                                                                    
Nov 11 13:21:47 terra org.gnome.Shell.desktop[2680]: could not connect to wayland server                                                                                                                           
Nov 11 13:21:47 terra org.gnome.Shell.desktop[2680]: (EE)                                                                                                                                                          
Nov 11 13:21:47 terra org.gnome.Shell.desktop[2680]: Fatal server error:                                                                                                                                           Nov 11 13:21:47 terra org.gnome.Shell.desktop[2680]: (EE) Couldn't add screen                                                                                                                                      
Nov 11 13:21:47 terra org.gnome.Shell.desktop[2680]: (EE)                                                                                                                                                          
Nov 11 13:21:47 terra gnome-session[2611]: gnome-session-binary[2611]: WARNING: Application 'org.gnome.Shell.desktop' killed by signal 11                                                                          
Nov 11 13:21:47 terra gnome-session-binary[2611]: WARNING: Application 'org.gnome.Shell.desktop' killed by signal 11                                                                                               
Nov 11 13:21:47 terra gnome-session-binary[2611]: Unrecoverable failure in required component org.gnome.Shell.desktop 
```

