### PR TITLE
Disable LTO for app-text/yodl

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -107,6 +107,7 @@ sys-libs/libomp *FLAGS-=-flto* # Issue #619 libomp-11.0.0_rc4 fails to build wit
 sys-devel/llvm FLAGS-=-flto* # Issue #619 temporarily disabled for now due to build errors
 sys-devel/clang FLAGS-=-flto* # Issue #619 Same as above
 sys-libs/libomp FLAGS-=-flto* # Issue #619 Same as above
+app-text/yodl *FLAGS-=-flto* # Fixes build
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Title: app-text/yodl:  Disable LTO

yodl doesn't build with LTO, this PR disables LTO so yodl can be compiled.