### PR TITLE
sys-libs/efivar-37: Added -flto-partition=none

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -370,3 +370,7 @@ app-text/evince NOCOMMON_OVERRIDE_LIBTOOL=yes
 dev-lang/ruby *FLAGS+=-fno-strict-aliasing # No build or runtime failures, but recommended by the package to avoid incorrect optimizations
 sys-libs/compiler-rt-sanitizers *FLAGS+=-Wno-unused-command-line-argument # Test failure
 #sys-devel/prelink EGIT_BRANCH="master_staging"
+
+# BEGIN: -flto-partition=none workarounds
+=sys-libs/efivar-37 *FLAGS+="-flto-partition=none"
+# END: -flto-partition=none workarounds


### PR DESCRIPTION
Package sys-libs/efivar-37 fails with the following error:

```
Error: invalid attempt to declare external version name as default in symbol `efi_set_variable@@LIBEFIVAR_0.24'
lto-wrapper: fatal error: cc returned 1 exit status
compilation terminated.
/usr/bin/ld: error: lto-wrapper failed

```
Adding "-flto-partition=none" to CFLAGS fixes the issue.

Upstream bug report: https://github.com/rhboot/efivar/issues/156
