### PR TITLE
Fix for issue #581

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -109,6 +109,7 @@ app-text/yodl *FLAGS-=-flto* # Fixes build
 sys-devel/llvm *FLAGS-=-flto* # Issue #619 temporarily disabled for now due to build errors
 sys-devel/clang *FLAGS-=-flto* # Issue #619 Same as above
 sys-libs/libomp *FLAGS-=-flto* # Issue #619 Same as above
+gnustep-base/gnustep-make *FLAGS-=-flto* # Issue #581, tools to build gnustep-base/gnustep-base, if built with LTO doesn't build gnustep code
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Closes #581 

If the building tools (`gnustep-base/gnustep-base`) is built with LTO,
when the base program is compiled the error in #581 appears, since the
building tools doesn't play well with LTO