### PR TITLE
dev-lang/jimtcl: disable SEMINTERPOS

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -291,6 +291,7 @@ net-print/cups *FLAGS-="${SEMINTERPOS}" # ICE
 sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
 sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
 app-emulation/libvirt *FLAGS-="${SEMINTERPOS}" # Test failure
+dev-lang/jimtcl *FLAGS-="${SEMINTERPOS}" # buffer overflow error when running an autosetup script.
 # END: Semantic Interposition Workarounds
 
 # BEGIN: No PLT workarounds


### PR DESCRIPTION
Fixes buffer overflow error when running an autosetup script, which `mail-client/neomutt` uses in it's configure script.

This is the error message when attempting to merge `mail-client/neomutt` with SEMINTERPOS enabled in `dev-lang/jimtcl`.

```
>>> Configuring source in /var/tmp/portage/mail-client/neomutt-20201127-r1/work/neomutt-20201127 ...
./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --libdir=/usr/lib64 CCACHE=none --disable-doc --enable-nls --enable-notmuch --enable-gpgme --disable-pgp --disable-smime --disable-bdb --enable-gdbm --disable-kyotocabinet --disable-qdbm --disable-tokyocabinet --disable-idn --disable-gss --enable-lmdb --enable-sasl --with-ui=ncurses --sysconfdir=/etc/neomutt --enable-ssl --disable-gnutls --disable-testing
*** buffer overflow detected ***: terminated
/usr/lib/portage/python3.7/phase-helpers.sh: line 563:    65 Aborted                 "${ECONF_SOURCE}/configure" "$@"
```