### PR TITLE
lto-rebuild: set source directory to ${WORKDIR}

### DIFF
--- a/app-portage/lto-rebuild/lto-rebuild-0.9.8-r1.ebuild
+++ b/app-portage/lto-rebuild/lto-rebuild-0.9.8-r1.ebuild
@@ -12,6 +12,8 @@ KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND="app-portage/portage-utils"
 
+S="${WORKDIR}"
+
 src_install() {
 	dobin "${FILESDIR}/lto-rebuild"
 }


### PR DESCRIPTION
Default Source Directory Setting

In EAPI versions before 5, the variable `S` would default to `${WORKDIR}/${P}`. But if `${P}` did not exist, the ebuild would silently fall back to the work directory (`${WORKDIR}`). For some ebuilds, this wasn't a problem because they only installed files out of `${FILESDIR}` or `${SYSROOT}`. 

Starting with EAPI 5, the PM no longer does this automatic fallback to `${WORKDIR}`. If you get errors like "`The source directory '...' doesn't exist`", then you're hitting this problem (i.e. relying on the older silent fallback behavior).

The easy answer is usually to set `S` to `${WORKDIR}`.This might not be the right answer (maybe your source lives somewhere else), but frequently this is OK. So after the `DEPEND/RDEPEND` variables and before any of the src_* or pkg_* functions, add:

`S=${WORKDIR}`

From https://www.chromium.org/chromium-os/how-tos-and-troubleshooting/upgrade-ebuild-eapis.