### PR TITLE
Enable multiprocessor for zstd by default

### DIFF
--- a/sys-config/ltoize/files/patches/app-arch/zstd-1.4.7/zstd-1.4.7-multi-thread-default.patch
+++ b/sys-config/ltoize/files/patches/app-arch/zstd-1.4.7/zstd-1.4.7-multi-thread-default.patch
@@ -1,0 +1,23 @@
+--- a/programs/README.md
++++ b/programs/README.md
+@@ -172,7 +172,7 @@
+ --long[=#]: enable long distance matching with given window log (default: 27)
+ --fast[=#]: switch to very fast compression levels (default: 1)
+ --adapt : dynamically adapt compression level to I/O conditions
+- -T#    : spawns # compression threads (default: 1, 0==# cores)
++ -T#    : spawns # compression threads (default: 0==# cores)
+  -B#    : select size of each job (default: 0==automatic)
+ --single-thread : use a single thread for both I/O and compression (result slightly different than -T1)
+ --rsyncable : compress using a rsync-friendly method (-B sets block size)
+
+--- a/programs/zstdcli.c
++++ b/programs/zstdcli.c
+@@ -21,7 +21,7 @@
+ #endif
+ 
+ #ifndef ZSTDCLI_NBTHREADS_DEFAULT
+-#  define ZSTDCLI_NBTHREADS_DEFAULT 1
++#  define ZSTDCLI_NBTHREADS_DEFAULT 0
+ #endif
+ 
+ /*-************************************


### PR DESCRIPTION
This applies to app-arch/zstd-1.4.7, enabling the multiprocessor as default option

It's the continuation of #664 and #663 
