### PR TITLE
Add fix for media-libs/x264 failing at configure phase

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -14,6 +14,7 @@ sys-power/nut *FLAGS+=-ffat-lto-objects # fails during configure otherwise
 media-libs/libvpx *FLAGS+=-ffat-lto-objects # Test failure
 net-libs/quiche *FLAGS+=-ffat-lto-objects # relocation R_X86_64_PC32 against undefined hidden symbol `GFp_ia32cap_P' can not be used when making a shared object
 dev-util/sccache *FLAGS+=-ffat-lto-objects # fails to link
+media-libs/x264 *FLAGS+=-ffat-lto-objects		#fails configure phase with no listed error
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*


### PR DESCRIPTION
Title: media-libs/x264: fails at configuration phase without --ffat-lto-objects

Ensure that any added workarounds have a comment explaining the compilation error which requires it.
Any removed workarounds should be moved to the fixed section.
If an issue exists, please link it.
See .github/CONTRIBUTING.md for more information.
