### PR TITLE
media-libs/x264|-encoder/lto.patch: fix failing endian test.

### DIFF
--- a/app-portage/lto-rebuild/lto-rebuild-0.9.8.ebuild
+++ b/app-portage/lto-rebuild/lto-rebuild-0.9.8.ebuild
@@ -12,6 +12,8 @@ KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND="app-portage/portage-utils"
 
+S="${WORKDIR}"
+
 src_install() {
 	dobin "${FILESDIR}/lto-rebuild"
 }

--- a/sys-config/ltoize/files/patches/media-libs/x264/lto.patch
+++ b/sys-config/ltoize/files/patches/media-libs/x264/lto.patch
@@ -5,7 +5,7 @@
  if [ $compiler = GNU ]; then
      echo "int i[2] = {0x42494745,0}; double f[2] = {0x1.0656e6469616ep+102,0};" > conftest.c
 -    $CC $CFLAGS conftest.c -c -o conftest.o 2>/dev/null || die "endian test failed"
-+    $CC $CFLAGS conftest.c -c -o conftest.o -shared 2>/dev/null || die "endian test failed"
++    $CC $CFLAGS conftest.c -o conftest.o -shared 2>/dev/null || die "endian test failed"
      if (${STRINGS} -a conftest.o | grep -q BIGE) && (${STRINGS} -a conftest.o | grep -q FPendian) ; then
          define WORDS_BIGENDIAN
          CPU_ENDIAN="big-endian"

--- a/sys-config/ltoize/files/patches/media-video/x264-encoder/lto.patch
+++ b/sys-config/ltoize/files/patches/media-video/x264-encoder/lto.patch
@@ -5,7 +5,7 @@
  if [ $compiler = GNU ]; then
      echo "int i[2] = {0x42494745,0}; double f[2] = {0x1.0656e6469616ep+102,0};" > conftest.c
 -    $CC $CFLAGS conftest.c -c -o conftest.o 2>/dev/null || die "endian test failed"
-+    $CC $CFLAGS conftest.c -c -o conftest.o -shared 2>/dev/null || die "endian test failed"
++    $CC $CFLAGS conftest.c -o conftest.o -shared 2>/dev/null || die "endian test failed"
      if (${STRINGS} -a conftest.o | grep -q BIGE) && (${STRINGS} -a conftest.o | grep -q FPendian) ; then
          define WORDS_BIGENDIAN
          CPU_ENDIAN="big-endian"


### PR DESCRIPTION
  Without linking ("-c") the endian tests fail for:
  media-libs/x264 and
  media-libs/x264-encoder

  See: https://github.com/InBetweenNames/gentooLTO/issues/671