### PR TITLE
games-fps/gzdoom: Disabled LTO + Force Emake

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -17,7 +17,7 @@ dev-util/sccache *FLAGS+=-ffat-lto-objects # fails to link
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*
-games-fps/gzdoom *FLAGS-=-flto*
+games-fps/gzdoom *FLAGS-=-flto* # Assertion `Class != nullptr' failed. SIGABRT
 app-emulation/libpod *FLAGS-=-flto*
 app-emulation/qemu *FLAGS-=-flto* *FLAGS+=-fno-strict-aliasing # required to compile qemu
 media-libs/alsa-lib *FLAGS-=-flto*
@@ -193,7 +193,7 @@ dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `im
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja
-games-fps/gzdoom CMAKE_MAKEFILE_GENERATOR=emake
+games-fps/gzdoom CMAKE_MAKEFILE_GENERATOR=emake #"$@" || die "${nonfatal_args[@]}" "${*} failed"
 x11-misc/polybar CMAKE_MAKEFILE_GENERATOR=emake
 app-doc/doxygen CMAKE_MAKEFILE_GENERATOR=emake
 dev-lang/swi-prolog CMAKE_MAKEFILE_GENERATOR=emake

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -17,6 +17,7 @@ dev-util/sccache *FLAGS+=-ffat-lto-objects # fails to link
 
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*
+games-fps/gzdoom *FLAGS-=-flto*
 app-emulation/libpod *FLAGS-=-flto*
 app-emulation/qemu *FLAGS-=-flto* *FLAGS+=-fno-strict-aliasing # required to compile qemu
 media-libs/alsa-lib *FLAGS-=-flto*
@@ -192,6 +193,7 @@ dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `im
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja
+games-fps/doom CMAKE_MAKEFILE_GENERATOR=emake
 x11-misc/polybar CMAKE_MAKEFILE_GENERATOR=emake
 app-doc/doxygen CMAKE_MAKEFILE_GENERATOR=emake
 dev-lang/swi-prolog CMAKE_MAKEFILE_GENERATOR=emake

--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -193,7 +193,7 @@ dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `im
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja
-games-fps/doom CMAKE_MAKEFILE_GENERATOR=emake
+games-fps/gzdoom CMAKE_MAKEFILE_GENERATOR=emake
 x11-misc/polybar CMAKE_MAKEFILE_GENERATOR=emake
 app-doc/doxygen CMAKE_MAKEFILE_GENERATOR=emake
 dev-lang/swi-prolog CMAKE_MAKEFILE_GENERATOR=emake


### PR DESCRIPTION
GZDoom doesn't build otherwise, unfortuanetly. According to [this issue](https://github.com/InBetweenNames/gentooLTO/issues/524), it also doesn't work with ninja. Although I didn't test this for myself, I disabled it too just in case.
