### PR TITLE
games-fps/gzdoom: Removed Force Emake

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -193,7 +193,6 @@ dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `im
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja
-games-fps/gzdoom CMAKE_MAKEFILE_GENERATOR=emake #"$@" || die "${nonfatal_args[@]}" "${*} failed"
 x11-misc/polybar CMAKE_MAKEFILE_GENERATOR=emake
 app-doc/doxygen CMAKE_MAKEFILE_GENERATOR=emake
 dev-lang/swi-prolog CMAKE_MAKEFILE_GENERATOR=emake


### PR DESCRIPTION
GZDoom builds just fine with ninja. I took the word of the Github issue that inspired me to make this commit in the first place (#524).