### PR TITLE
games-fps/zandronum: Disabled LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -18,6 +18,7 @@ dev-util/sccache *FLAGS+=-ffat-lto-objects # fails to link
 #Packages which cannot be built with LTO at all (previously was nolto.conf)
 dev-util/perf *FLAGS-=-flto*
 games-fps/gzdoom *FLAGS-=-flto* # Assertion `Class != nullptr' failed. SIGABRT
+games-fps/zandronum *FLAGS-=-flto* #Can't read wads properly with LTO
 app-emulation/libpod *FLAGS-=-flto*
 app-emulation/qemu *FLAGS-=-flto* *FLAGS+=-fno-strict-aliasing # required to compile qemu
 media-libs/alsa-lib *FLAGS-=-flto*
@@ -193,7 +194,6 @@ dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `im
 # END: -Ofast workarounds
 
 # BEGIN: Will not build with ninja
-games-fps/gzdoom CMAKE_MAKEFILE_GENERATOR=emake #"$@" || die "${nonfatal_args[@]}" "${*} failed"
 x11-misc/polybar CMAKE_MAKEFILE_GENERATOR=emake
 app-doc/doxygen CMAKE_MAKEFILE_GENERATOR=emake
 dev-lang/swi-prolog CMAKE_MAKEFILE_GENERATOR=emake


### PR DESCRIPTION
Similar to GZDoom, Zandronum doesn't start when LTO is enabled. Though, interestingly, it will run, but it can't properly read Doom .wad files. Both GZDoom and Zandronum are based off of ZDoom, so that could be it.