### PR TITLE
ltoworkarounds: remove media-libs/flac -fno-ipa-cp-clone

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -164,7 +164,6 @@ net-mail/mailutils "has ldap ${IUSE//+} && use ldap && FlagAdd LDFLAGS -llber" #
 dev-lisp/clisp *FLAGS+=-falign-functions # Issue #128.  Function alignment problem.
 
 # BEGIN: Deliberate -O3 workarounds
-media-libs/flac *FLAGS+=-fno-ipa-cp-clone # -fipa-cp-clone is enabled by default at -O3, breaks 'flac -d' if used in conjunction with -flto under GCC 8.3.0
 media-libs/faad2 *FLAGS+=-fno-tree-loop-vectorize # causes subtly wrong decoding
 kde-frameworks/kactivities-stats /-O3/-O2 # causes systemsettings5 to crash
 mail-filter/procmail /-O3/-O2 # Causes compile to hang indefinitely


### PR DESCRIPTION
`flac -d` works fine without it on my system with gcc 10.2.0

It also breaks configure with clang, as clang doesn't support the flag.