### PR TITLE
introduce clang.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ The default configuration of GentooLTO enables the following:
 
 ---
 
-**GentooLTO uses `ld.bfd` as the default linker**
+**GentooLTO with GCC uses `ld.bfd` as the default linker**
+
+**If you have the `sys-config/ltoize` `clang` USE flag enabled, certain overrides assume you are using the `ld.lld` linker and Thin LTO**
 
 ---
 
-GentooLTO was previously using `ld.gold` as the default linker, but it appears that it is not being maintained upstream anymore, except for minor bugfixes. `ld.gold` is still supported by GentooLTO and workarounds are still being accepted in `ltoworkarounds.conf`, but going forward the recommended linker will be `ld.bfd`.
+GentooLTO was previously using `ld.gold` as the default linker, but it appears that it is not being maintained upstream anymore, except for minor bugfixes. `ld.gold` is still supported by GentooLTO and workarounds are still being accepted, but going forward the recommended linker will be `ld.bfd`.
 
 If you'd like to override the default configuration, you can source `make.conf.lto.defines` instead. This file contains the definitions for the variables that `sys-config/ltoize` uses for the optimization flags. Using this file directly, you can cherry-pick and define your own config.  For example:
 

--- a/sys-config/ltoize/files/bashrc.d/44-lto-clang-full.sh
+++ b/sys-config/ltoize/files/bashrc.d/44-lto-clang-full.sh
@@ -1,0 +1,9 @@
+LTO_CLANG_FULL() {
+    if [[ ${LTO_FULL} -eq 1 ]]; then
+        export CFLAGS="${CFLAGS//=thin}"
+        export CXXFLAGS="${CXXFLAGS//=thin}"
+        export LDFLAGS="${LDFLAGS//=thin}"
+    fi
+}
+
+BashrcdPhase configure LTO_CLANG_FULL

--- a/sys-config/ltoize/files/package.cflags/clang.conf
+++ b/sys-config/ltoize/files/package.cflags/clang.conf
@@ -1,0 +1,9 @@
+# BEGIN: Workarounds for LTO with Clang
+dev-libs/libgcrypt *FLAGS-=-flto* # https://bugs.gentoo.org/765841
+dev-lang/python *FLAGS-=-flto* # https://bugs.gentoo.org/700012 : No -ffat-lto-objects on clang
+dev-util/colm *FLAGS-=-flto* # ld: libcolm.a: error adding symbols: file format not recognized
+# END: Workarounds for LTO with Clang
+
+# BEGIN: Packages which require Full LTO
+media-libs/libglvnd LTO_FULL=1 # ld.lld: error: undefined symbol: entrypointFunctions
+# END: Packages which require Full LTO

--- a/sys-config/ltoize/ltoize-0.9.9.ebuild
+++ b/sys-config/ltoize/ltoize-0.9.9.ebuild
@@ -1,0 +1,126 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="A configuration for portage to make building with LTO easy"
+HOMEPAGE="https://github.com/InBetweenNames/gentooLTO"
+
+#Note: there's nothing preventing this from working on stable, but the dependencies of ltoize aren't keyworded for
+#stable, so we only can do testing
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+
+SRC_URI=""
+
+LICENSE="GPL-2+"
+SLOT="0"
+IUSE="clang keep-nocommon override-flagomatic"
+
+#portage-bashrc-mv can be obtained from mv overlay
+DEPEND="
+	app-portage/portage-bashrc-mv[cflags]
+	sys-apps/portage
+	sys-devel/gcc-config
+"
+RDEPEND="${DEPEND}"
+
+#Test binutils and gcc version
+pkg_setup() {
+
+	ACTIVE_GCC=$(gcc-fullversion)
+
+	if ver_test "${ACTIVE_GCC}" -lt 10.2.0; then
+		ewarn "Warning: Active GCC version '$ACTIVE_GCC' is lower then the expected version '10.2.0', it is recommended that you use the newest GCC if you want LTO."
+		if [ "${I_KNOW_WHAT_I_AM_DOING}" != "y" ]; then
+			eerror "Aborting LTOize installation due to older GCC version '$ACTIVE_GCC' -- set I_KNOW_WHAT_I_AM_DOING=y if you want to override this behaviour."
+			die
+		else
+			ewarn "I_KNOW_WHAT_I_AM_DOING=y -- continuing anyway"
+		fi
+	fi
+
+	if [ -f "${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags" ]; then
+		eerror "${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags is a file not a directory.  Please convert package.cflags to a directory with the current contents of package.cflags being moved to a file inside it."
+		die
+	fi
+
+}
+
+pkg_preinst() {
+	ACTIVE_GCC=$(gcc-fullversion)
+	GENTOOLTO_PORTDIR=$(portageq get_repo_path ${PORTAGE_CONFIGROOT} lto-overlay)
+	LTO_PORTAGE_DIR="${GENTOOLTO_PORTDIR}/${CATEGORY}/${PN}/files"
+
+	COMMON_WORKAROUNDS=(
+		cmake-makefile.conf
+		devirtualize-at-ltrans.conf
+		graphite.conf
+		ipa-pta.conf
+		lto.conf
+		no-common-libtool.conf
+		no-plt.conf
+		no-semantic-interposition.conf
+		optimizations.conf
+		tls-dialect.conf
+		use-ld.conf
+	)
+
+	#Install make.conf settings
+	elog "Installing make.conf.lto.defines definitions for optimizations used in this overlay"
+	dosym "${LTO_PORTAGE_DIR}/make.conf.lto.defines" "${PORTAGE_CONFIGROOT%/}/etc/portage/make.conf.lto.defines"
+
+	elog "Installing make.conf.lto default full optimization config for make.conf"
+	dosym "${LTO_PORTAGE_DIR}/make.conf.lto" "${PORTAGE_CONFIGROOT%/}/etc/portage/make.conf.lto"
+
+	#Install main workarounds files
+	for i in "${COMMON_WORKAROUNDS[@]}"; do
+		elog "Installing package.cflags ${i} override"
+		dosym "${LTO_PORTAGE_DIR}/package.cflags/${i}" "${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags/${i}"
+	done
+
+	#Install -fno-common workarounds file
+	use keep-nocommon && dosym "${LTO_PORTAGE_DIR}/package.cflags/no-common.conf" \
+	"${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags/no-common.conf"
+
+	# Install Clang LTO workarounds
+	use clang && dosym "${LTO_PORTAGE_DIR}/package.cflags/clang.conf" \
+	"${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags/clang.conf"
+
+	#Install patch framework
+	elog "Installing bashrc.d hook symlink to apply LTO patches directly from lto-overlay"
+	dosym "${LTO_PORTAGE_DIR}/bashrc.d/41-lto-patch.sh" "${PORTAGE_CONFIGROOT%/}/etc/portage/bashrc.d/41-lto-patch.sh"
+
+	#Optional: install flag-o-matic overrides
+	if use override-flagomatic; then
+		ewarn "Installing bashrc.d hook to override strip-flags and replace-flags functions in flag-o-matic.  This is an experimental feature!"
+		dosym "${LTO_PORTAGE_DIR}/bashrc.d/42-lto-flag-o-matic.sh" "${PORTAGE_CONFIGROOT%/}/etc/portage/bashrc.d/42-lto-flag-o-matic.sh"
+		dosym "${LTO_PORTAGE_DIR}/package.cflags/flag-o-matic.conf" "${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags/flag-o-matic.conf"
+	fi
+
+	elog "Installing bashrc.d hook symlink to override package libtool lt_cv_sys_global_symbol_pipe and lt_cv_sys_global_symbol_to_cdecl"
+	dosym "${LTO_PORTAGE_DIR}/bashrc.d/43-lto-no-common.sh" "${PORTAGE_CONFIGROOT%/}/etc/portage/bashrc.d/43-lto-no-common.sh"
+}
+
+pkg_postinst()
+{
+	elog "If you have not done so, you will need to modify your make.conf settings to enable LTO building on your system."
+	elog "A symlink has been placed in ${PORTAGE_CONFIGROOT%/}/etc/portage/make.conf.lto that can be used as a basis for these modifications."
+	elog "See README.md for more details."
+	elog "lto-overlay and ltoize are part of a project to help find undefined behaviour in C and C++ programs through the use of aggressive compiler optimizations."
+	elog "One of the aims of this project is also to improve the performance of linux distributions through these mechanisms as well."
+	elog "Occasionally, you will experience breakage due to LTO problems.  These are documented in the README.md of this repository."
+	elog "If you add an override for a particular package, please consider sending a pull request upstream so that other users of this repository can benefit."
+	ewarn "You will require a complete system rebuild in order to gain the benefits of LTO system-wide."
+	echo
+	elog "Please consider reading the README.md at the root of this repository before attempting to rebuild your system to familiarize yourself with the goals of this project and potential pitfalls you could run into."
+	echo
+	ewarn "This is an experimental project and should not be used on a stable system in its current state."
+
+	BINUTILS_VER=$(binutils-config ${CHOST} -c | sed -e "s/.*-//")
+
+	if ver_test "${BINUTILS_VER}" -lt 2.34; then
+		ewarn "Warning: active binutils version < 2.34, it is recommended that you use the newest binutils for LTO."
+	fi
+}

--- a/sys-config/ltoize/metadata.xml
+++ b/sys-config/ltoize/metadata.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-<email>lookatyouhacker@gmail.com</email>
-<name>Shane Peelar</name>
-</maintainer>
-<longdescription lang="en">
-LTOize is a set of configuration files and overrides to make building your system Link Time Optimization easy.  This is part of a bigger initiative to find errors in C and C++ programs that are caused by undefined behaviour.  Users are strongly encouraged to contribute their configuration changes upstream.  For more information, see the gentooLTO project on GitHub.
-</longdescription>
-<use><flag name="override-flagomatic">Override strip-flags and replace-flags in flag-o-matic.eclass (EXPERIMENTAL)</flag>
-<flag name="keep-nocommon">Keep old -fno-common overrides for older GCCs (not recommended)</flag></use>
+    <maintainer type="person">
+        <email>lookatyouhacker@gmail.com</email>
+        <name>Shane Peelar</name>
+    </maintainer>
+    <longdescription lang="en">
+        LTOize is a set of configuration files and overrides to make building your system Link Time Optimization easy.
+        This is part of a bigger initiative to find errors in C and C++ programs that are caused by undefined behaviour.
+        Users are strongly encouraged to contribute their configuration changes upstream.
+        For more information, see the gentooLTO project on GitHub.
+    </longdescription>
+    <use>
+        <flag name="clang">Install clang.conf overrides where LTO on Clang creates issues</flag>
+        <flag name="override-flagomatic">Override strip-flags and replace-flags in flag-o-matic.eclass (EXPERIMENTAL)</flag>
+        <flag name="keep-nocommon">Keep old -fno-common overrides for older GCCs (not recommended)</flag>
+    </use>
 </pkgmetadata>


### PR DESCRIPTION
```
--- sys-config/ltoize/ltoize-0.9.8.ebuild       2021-01-25 22:34:28.457112681 +1300
+++ sys-config/ltoize/ltoize-0.9.9.ebuild       2021-01-25 22:34:14.813000000 +1300
@@ -5,7 +5,7 @@
 
 inherit toolchain-funcs
 
-DESCRIPTION="A configuration for portage to make building with LTO easy."
+DESCRIPTION="A configuration for portage to make building with LTO easy"
 HOMEPAGE="https://github.com/InBetweenNames/gentooLTO"
 
 #Note: there's nothing preventing this from working on stable, but the dependencies of ltoize aren't keyworded for
@@ -16,20 +16,17 @@
 
 LICENSE="GPL-2+"
 SLOT="0"
-IUSE="override-flagomatic keep-nocommon"
+IUSE="clang keep-nocommon override-flagomatic"
 
 #portage-bashrc-mv can be obtained from mv overlay
 DEPEND="
-       >=sys-devel/binutils-2.32:*
-       >=sys-devel/gcc-config-1.9.1
-       >=sys-apps/portage-2.3.52
        app-portage/portage-bashrc-mv[cflags]
-       "
-
+       sys-apps/portage
+       sys-devel/gcc-config
+"
 RDEPEND="${DEPEND}"
 
 #Test binutils and gcc version
-
 pkg_setup() {
 
        ACTIVE_GCC=$(gcc-fullversion)
@@ -52,8 +49,10 @@
 }
 
 pkg_preinst() {
+       ACTIVE_GCC=$(gcc-fullversion)
        GENTOOLTO_PORTDIR=$(portageq get_repo_path ${PORTAGE_CONFIGROOT} lto-overlay)
        LTO_PORTAGE_DIR="${GENTOOLTO_PORTDIR}/${CATEGORY}/${PN}/files"
+
        COMMON_WORKAROUNDS=(
                cmake-makefile.conf
                devirtualize-at-ltrans.conf
@@ -68,10 +67,7 @@
                use-ld.conf
        )
 
-       ACTIVE_GCC=$(gcc-fullversion)
-
        #Install make.conf settings
-
        elog "Installing make.conf.lto.defines definitions for optimizations used in this overlay"
        dosym "${LTO_PORTAGE_DIR}/make.conf.lto.defines" "${PORTAGE_CONFIGROOT%/}/etc/portage/make.conf.lto.defines"
 
@@ -88,6 +84,10 @@
        use keep-nocommon && dosym "${LTO_PORTAGE_DIR}/package.cflags/no-common.conf" \
        "${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags/no-common.conf"
 
+       # Install Clang LTO workarounds
+       use clang && dosym "${LTO_PORTAGE_DIR}/package.cflags/clang.conf" \
+       "${PORTAGE_CONFIGROOT%/}/etc/portage/package.cflags/clang.conf"
+
        #Install patch framework
        elog "Installing bashrc.d hook symlink to apply LTO patches directly from lto-overlay"
        dosym "${LTO_PORTAGE_DIR}/bashrc.d/41-lto-patch.sh" "${PORTAGE_CONFIGROOT%/}/etc/portage/bashrc.d/41-lto-patch.sh"
@@ -101,7 +101,6 @@
 
        elog "Installing bashrc.d hook symlink to override package libtool lt_cv_sys_global_symbol_pipe and lt_cv_sys_global_symbol_to_cdecl"
        dosym "${LTO_PORTAGE_DIR}/bashrc.d/43-lto-no-common.sh" "${PORTAGE_CONFIGROOT%/}/etc/portage/bashrc.d/43-lto-no-common.sh"
-
 }
 
 pkg_postinst()
```