### PR TITLE
change relative paths to absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This will add the necessary overrides to `/etc/portage/`, but it won't modify yo
 #Set this to "auto" to have gcc determine optimal number of cores (GCC 10+)
 NTHREADS="12"
 
-source make.conf.lto
+source /etc/portage/make.conf.lto
 
 CFLAGS="-march=native ${CFLAGS} -pipe" #NOTE: Consider using -falign-functions=32 if you use an Intel processor.  See issue #164.
 CXXFLAGS="${CFLAGS}"
@@ -104,7 +104,7 @@ If you'd like to override the default configuration, you can source `make.conf.l
 ~~~ bash
 NTHREADS="12"
 
-source make.conf.lto.defines
+source /etc/portage/make.conf.lto.defines
 
 CFLAGS="-march=native -O3 ${SEMINTERPOS} ${GRAPHITE} ${IPA} ${FLTO} -fuse-linker-plugin -pipe" #NOTE: consider using -falign-functions=32 if you use an Intel processor (Sandy Bridge or later).  See issue #164.
 CXXFLAGS="${CFLAGS}"

--- a/sys-config/ltoize/files/make.conf.lto
+++ b/sys-config/ltoize/files/make.conf.lto
@@ -12,7 +12,7 @@
 #You may also set this to "auto" to have gcc determine optimal number of cores (GCC 10+) 
 #After this, but before any other variables are defined, source this file directly:
 
-#source make.conf.lto
+#source /etc/portage/make.conf.lto
 
 #Then, afterwards, define your CFLAGS with your own options:
 
@@ -71,7 +71,7 @@
 #If you want to cherry pick these settings, source make.conf.lto.defines directly
 #and read the comments in that file.
 
-source make.conf.lto.defines
+source /etc/portage/make.conf.lto.defines
 
 #Thanks to issue #49, no action necessary for preventing stripping of static libraries
 


### PR DESCRIPTION
This PR will allow for package and use flag managers to work with gentooLTO, referenced here: #320 and here: #660. In my opinion, this is the way to resolve both cleanly, although I understand any adversity towards absolute over relative paths. Seeing as portage configuration should be stored in `/etc/portage/` however, absolute paths shouldn't matter and I think this is the way to go about fixing those issues.