### PR TITLE
clang.conf: remove dev-libs/libgcrypt workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/clang.conf
+++ b/sys-config/ltoize/files/package.cflags/clang.conf
@@ -1,5 +1,4 @@
 # BEGIN: Workarounds for LTO with Clang
-dev-libs/libgcrypt *FLAGS-=-flto* # https://bugs.gentoo.org/765841
 dev-lang/python *FLAGS-=-flto* # https://bugs.gentoo.org/700012 : No -ffat-lto-objects on clang
 dev-util/colm *FLAGS-=-flto* # ld: libcolm.a: error adding symbols: file format not recognized
 # END: Workarounds for LTO with Clang


### PR DESCRIPTION
fixed in dev-libs/libgcrypt-1.9.1

https://dev.gnupg.org/T5255