### PR TITLE
dev-db/firebird: package.cflags typo

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -17,7 +17,7 @@ app-text/yodl *FLAGS-=-flto* # Fixes build
 cross-arm-none-eabi/newlib *FLAGS-=-flto* # Causes 'arm-none-eabi-gcc' to segfault
 cross-i686-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
-dev-db/firebird *FLAGS=-flto*
+dev-db/firebird *FLAGS-=-flto*
 dev-db/mariadb *FLAGS-=-flto*
 dev-db/mysql-connector-c *FLAGS-=-flto* # required to compiled mysql-connector-c
 games-fps/gzdoom *FLAGS-=-flto* # Assertion `Class != nullptr' failed. SIGABRT


### PR DESCRIPTION
*FLAGS=-flto* forcefully enables lto, and breaks all other *FLAGS. 
Fixed before, it seems
