### PR TITLE
dev-util/umockdev: Disable -fno-semantic-interposition

### DIFF
--- a/sys-config/ltoize/files/package.cflags/no-semantic-interposition.conf
+++ b/sys-config/ltoize/files/package.cflags/no-semantic-interposition.conf
@@ -4,6 +4,7 @@ app-emulation/libvirt *FLAGS-="${SEMINTERPOS}" # Test failure
 app-misc/tracker *FLAGS-="${SEMINTERPOS}" # builds but makes gnome-base/nautilus deadlock
 dev-lang/jimtcl *FLAGS-="${SEMINTERPOS}" # buffer overflow error when running an autosetup script.
 dev-lang/swi-prolog *FLAGS-="${SEMINTERPOS}" # segfaults during build
+dev-util/umockdev *FLAGS-="${SEMINTERPOS}" # /usr/include/bits/unistd.h:145:1: error: inlining failed in call to 'always_inline' 'readlink.localalias': function not inlinable
 media-sound/ardour *FLAGS-="${SEMINTERPOS}" # ICE in record_target_from_binfo during GIMPLE pass
 net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
 net-libs/libiscsi *FLAGS-="${SEMINTERPOS}"


### PR DESCRIPTION
```/var/tmp/portage/dev-util/umockdev-0.12.1/work/umockdev-0.12.1/src/libumockdev-preload.c: In function 'get_rdev':
/usr/include/bits/unistd.h:145:1: error: inlining failed in call to 'always_inline' 'readlink.localalias': function not inlinable
  145 | __NTH (readlink (const char *__restrict __path, char *__restrict __buf,
      | ^
/var/tmp/portage/dev-util/umockdev-0.12.1/work/umockdev-0.12.1/src/libumockdev-preload.c:189:9: note: called from here
  189 |     if (readlink(buf, link, sizeof(link)) < 0) {
      |         ^```
