### PR TITLE
dev-libs/folks: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -30,6 +30,7 @@ dev-lang/perl *FLAGS-=-flto*
 dev-lang/rust *FLAGS-=-flto*
 dev-lang/spidermonkey *FLAGS-=-flto*
 dev-libs/elfutils *FLAGS-=-flto*
+dev-libs/folks *FLAGS-=-flto* # Programs which depend on folks fail to launch, https://gitlab.gnome.org/GNOME/folks/-/issues/123
 dev-libs/intel-neo *FLAGS-=-flto* # error: violates the C++ One Definition Rule [-Werror=odr]
 dev-libs/libsigsegv *FLAGS-=-flto* # Issue #189
 dev-libs/weston *FLAGS-=-flto*

--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -30,7 +30,6 @@ dev-lang/perl *FLAGS-=-flto*
 dev-lang/rust *FLAGS-=-flto*
 dev-lang/spidermonkey *FLAGS-=-flto*
 dev-libs/elfutils *FLAGS-=-flto*
-dev-libs/folks *FLAGS-=-flto* # Programs which depend on folks fail to launch, https://gitlab.gnome.org/GNOME/folks/-/issues/123
 dev-libs/intel-neo *FLAGS-=-flto* # error: violates the C++ One Definition Rule [-Werror=odr]
 dev-libs/libsigsegv *FLAGS-=-flto* # Issue #189
 dev-libs/weston *FLAGS-=-flto*
@@ -124,6 +123,7 @@ x11-terms/alacritty *FLAGS+=-ffat-lto-objects
 app-cdr/cdrtools *FLAGS-=-flto* # SCSI buffer size 0 when attempting to burn disc, reports "Unknown error 64512"
 app-crypt/gcr *FLAGS-=-flto* # Test failure
 dev-lang/ruby *FLAGS-=-flto* # Test failure
+dev-libs/folks *FLAGS-=-flto* # Programs which depend on folks fail to launch, https://gitlab.gnome.org/GNOME/folks/-/issues/123
 >=dev-libs/gjs-1.66.1 *FLAGS-=-flto* # generates general protection fault when starting up gnome
 dev-libs/libaio *FLAGS-=-flto* # Issue #314, missing symbols in LTO build compared to non-LTO build, leads to problems with sys-fs/lvm2
 dev-libs/libbsd *FLAGS-=-flto* # Undefined symbol error when building mail-client/mailx


### PR DESCRIPTION
Compiles without errors, but breaks applications, such as gnome-maps
See [https://gitlab.gnome.org/GNOME/folks/-/issues/123](https://gitlab.gnome.org/GNOME/folks/-/issues/123)

This lets gnome-maps and gnome-contacts launch.
There are still things crashing and journal spam when the program launches, but it seems functional.

unrelated note, media-video/totem still won't launch