### PR TITLE
media-libs/lcms: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -52,6 +52,7 @@ kde-frameworks/kjs *FLAGS-=-flto* # Issue #181
 mail-filter/procmail *FLAGS-=-flto* # Causes compile to hang indefinitely
 media-gfx/shotwell *FLAGS-=-flto* #Library search error with LTO enabled
 media-libs/alsa-lib *FLAGS-=-flto*
+media-libs/lcms *FLAGS-=-flto*
 media-libs/mlt *FLAGS-=-flto*
 media-sound/pulseaudio *FLAGS-=-flto*
 media-video/ffmpeg *FLAGS-=-flto* #NOTE: Depending on your CPUFLAGS this may work with LTO.  The SSE intrinsics seem to cause problems in some cases. Only x86 requires workaround


### PR DESCRIPTION
with LTO fails with:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld:
<artificial>:(.text.startup+0x1c55): undefined reference to
`cmsCloseProfile'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:460: tificc] Error 1
```
