### PR TITLE
sys-apps/systemd: set optimizations to O2

### DIFF
--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -5,6 +5,7 @@ media-libs/faad2 *FLAGS+=-fno-tree-loop-vectorize # causes subtly wrong decoding
 media-libs/lcms /-O3/-O2 # Test failure
 net-misc/dhcp /-O3/-O2 # Runtime failure, DHCPDISCOVER doesn't work correctly - introduced with gcc 10?
 sci-libs/scotch /-O3/-O2 # Test failure
+sys-apps/systemd /-O3/-O2 # causes homectl to fail with protocol error
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds


### PR DESCRIPTION
with -O3 it compiles fine but homectl starts acting up.
homed logins and new user creations via `homectl create` fail with protocol error.