### PR TITLE
dev-qt/qtcore: Added Ofast workaround to fix scrolling in kde-apps/okular

### DIFF
--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -24,4 +24,5 @@ net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` return
 >=sys-devel/llvm-10.0.0 *FLAGS+='-fno-finite-math-only' # compiles fine but causes clang to fail to emerge with ``undefined reference to `__log10_finite'``
 >=sys-libs/glibc-2.30 /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 x11-misc/redshift *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-math-only causes a runtime error where the brightness values are interpreted incorrectly
+dev-qt/qtcore *FLAGS+='-fno-finite-math-only' # compiles fine but causes most forms of scrolling to stop working in okular
 # END: -Ofast workarounds


### PR DESCRIPTION
Most forms of scrolling in okular have been broken for a while (mouse wheel over the document, arrow keys, page up/down, clicking on links in the document or in the thumbnails/outline). I recently found that it was caused by building qtcore with `-ffinite-math-only`.
