### PR TITLE
net-libs/nodejs: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -57,6 +57,7 @@ media-libs/mlt *FLAGS-=-flto*
 media-sound/pulseaudio *FLAGS-=-flto*
 media-video/ffmpeg *FLAGS-=-flto* #NOTE: Depending on your CPUFLAGS this may work with LTO.  The SSE intrinsics seem to cause problems in some cases. Only x86 requires workaround
 media-video/mplayer *FLAGS-=-flto*
+>=net-libs/nodejs-16.0.0 *FLAGS-=-flto* # Linking errors, only works by using the `lto` useflag
 net-libs/webkit-gtk:3 *FLAGS-=-flto*
 net-libs/webkit-gtk:4 *FLAGS-=-flto*
 net-misc/autossh *FLAGS-=-flto* # Undefined references


### PR DESCRIPTION
Passing the LTO flag through CFLAGS causes linking errors, however, LTO can still be enabled by a recently added useflag.