### PR TITLE
app-office/libreoffice: build with clang and/or custom-cflags

### DIFF
--- a/sys-config/ltoize/files/package.cflags/clang.conf
+++ b/sys-config/ltoize/files/package.cflags/clang.conf
@@ -1,6 +1,7 @@
 # BEGIN: Workarounds for LTO with Clang
 dev-lang/python *FLAGS-=-flto* # https://bugs.gentoo.org/700012 : No -ffat-lto-objects on clang
 dev-util/colm *FLAGS-=-flto* # ld: libcolm.a: error adding symbols: file format not recognized
+>=app-office/libreoffice-7.1.2.2 "has clang ${IUSE//+} && use clang && NOLDADD=1" "has clang ${IUSE//+} && use clang && has custom-cflags ${IUSE//+} && use custom-cflags && FlagSubAllFlags ${GRAPHITE} ${DEVIRTLTO} ${IPAPTA} ${FLTO} -fuse-linker-plugin" # fails to configure, see issue #734
 # END: Workarounds for LTO with Clang
 
 # BEGIN: Packages which require Full LTO


### PR DESCRIPTION
fix #734 