### PR TITLE
media-libs/dav1d: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -111,6 +111,7 @@ sys-devel/llvm *FLAGS-=-flto* # Issue #619 temporarily disabled for now due to b
 sys-devel/clang *FLAGS-=-flto* # Issue #619 Same as above
 sys-libs/libomp *FLAGS-=-flto* # Issue #619 Same as above
 gnustep-base/gnustep-make *FLAGS-=-flto* # Issue #581, tools to build gnustep-base/gnustep-base, if built with LTO doesn't build gnustep code
+media-libs/dav1d *FLAGS-=-flto* # Starting with GCC 11.1.0, various undefined reference errors during linking
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Fails during linking with GCC 11.1.0