### PR TITLE
media-libs/mesa: disable IPAPTA to fix segfault

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ipa-pta.conf
+++ b/sys-config/ltoize/files/package.cflags/ipa-pta.conf
@@ -22,4 +22,5 @@ sys-devel/clang *FLAGS-="${IPAPTA}" # Test failure
 net-p2p/monero *FLAGS-="${IPAPTA}" # ICE with -fipa-pta
 mail-client/thunderbird *FLAGS-="${IPAPTA}" # ICE with GCC 10.2.0 (seen with thunderbird 68.12.0)
 >=dev-lang/spidermonkey-78.3.1 *FLAGS-="${IPAPTA}" # Segfault during build with GCC 10.2.0
+>=media-libs/mesa-21.1.0 *FLAGS-="${IPAPTA}" # Segfault with vulkan
 # END: -fipa-pta workarounds


### PR DESCRIPTION
RADV (AMDGPU) and Intel GPUs crash with Vulkan and IPAPTA enabled.

Vulkan was not working since mesa 21.1 on my AMD 6800xt when I used RADV (segfault). I found this post advising to remove IPAPTA, which indeed fixed the issue for me: https://forums.gentoo.org/viewtopic-t-1134963-highlight-mesa.html
