### PR TITLE
dev-lang/erlang: Disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -112,6 +112,7 @@ sys-devel/clang *FLAGS-=-flto* # Issue #619 Same as above
 sys-libs/libomp *FLAGS-=-flto* # Issue #619 Same as above
 gnustep-base/gnustep-make *FLAGS-=-flto* # Issue #581, tools to build gnustep-base/gnustep-base, if built with LTO doesn't build gnustep code
 media-libs/dav1d *FLAGS-=-flto* # Starting with GCC 11.1.0, various undefined reference errors during linking
+dev-lang/erlang *FLAGS-=-flto* # Starting with Erlang 24.0, yeccparser.erl: internal error in pass beam_kernel_to_ssa
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Build failures starting with 24.0 . Not entirely surprising, as this release came with significant VM changes to support JIT.