### PR TITLE
x11-base/xwayland: disable -fipa-pta to fix crash on GLX query

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ipa-pta.conf
+++ b/sys-config/ltoize/files/package.cflags/ipa-pta.conf
@@ -23,4 +23,5 @@ net-p2p/monero *FLAGS-="${IPAPTA}" # ICE with -fipa-pta
 mail-client/thunderbird *FLAGS-="${IPAPTA}" # ICE with GCC 10.2.0 (seen with thunderbird 68.12.0)
 >=dev-lang/spidermonkey-78.3.1 *FLAGS-="${IPAPTA}" # Segfault during build with GCC 10.2.0
 >=media-libs/mesa-21.1.0 *FLAGS-="${IPAPTA}" # Segfault with vulkan
+x11-base/xwayland *FLAGS-="${IPAPTA}" # SIGABRT when querying for GLX information
 # END: -fipa-pta workarounds


### PR DESCRIPTION
XWayland applications querying for GLX information (glxinfo,
spotify, lutris, anything GPU accelerated) crash the X server
when XWayland is compiled with -fipa-pta.

Fixes #766