### PR TITLE
dev-vcs/git: add -ffat-lto-objects workaround

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -140,6 +140,7 @@ dev-libs/protobuf *FLAGS-=-flto* #Upstream bug https://github.com/protocolbuffer
 dev-libs/rocr-runtime *FLAGS-=-flto* # Causes crashes in multiple OpenCL tools
 dev-qt/qtscript *FLAGS-=-flto* #LTO patch exists, but crashes on newer Qt versions.  Needs to be updated.
 dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
+dev-vcs/git *FLAGS+=-ffat-lto-objects # git clone results in "bad object" error
 media-libs/mesa "has video_cards_i965 ${IUSE//+} && use video_cards_i965 && FlagSubAllFlags -flto*"
 media-sound/jack2 *FLAGS-=-flto* # segfault in libjack.so.0.1.0 when ANY app trying to use it (breaks everithing built w/ JACK support)
 net-misc/networkmanager *FLAGS-=-flto* # Test failure


### PR DESCRIPTION
When compiling git without this workaround, cloning a remote repository results in a "bad object" error (the object in question seems to be random) most of the time.