### PR TITLE
net-analyzer/wireshark and dev-lang/lua: disable LTO 

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -25,6 +25,7 @@ games-fps/zandronum *FLAGS-=-flto* #Can't read wads properly with LTO
 dev-java/icedtea *FLAGS-=-flto*
 <dev-java/openjdk-14 *FLAGS-=-flto* # Issue #204, undefined references with LTO.
 dev-lang/erlang *FLAGS-=-flto* # Starting with Erlang 24.0, yeccparser.erl: internal error in pass beam_kernel_to_ssa
+dev-lang/lua *FLAGS-=-flto* # Causes issues building packages like neovim and awesomewm, fixes #772
 dev-lang/mono *FLAGS-=-flto*
 dev-lang/perl *FLAGS-=-flto*
 >=dev-lang/php-7.2.0 *FLAGS-=-flto* # lto-wrapper link failure / https://github.com/InBetweenNames/gentooLTO/issues/135
@@ -62,7 +63,6 @@ media-video/ffmpeg *FLAGS-=-flto* #NOTE: Depending on your CPUFLAGS this may wor
 media-video/mplayer *FLAGS-=-flto*
 net-libs/webkit-gtk:3 *FLAGS-=-flto*
 net-libs/webkit-gtk:4 *FLAGS-=-flto*
-net-analyzer/wireshark *FLAGS-=-flto* # Segfaults trying to load GUI on QT5, see issue 746
 net-misc/autossh *FLAGS-=-flto* # Undefined references
 net-misc/dhcp "has server ${IUSE//+} && use server && FlagSubAllFlags -flto*" # Cannot be built with LTO by default, but can if "server" USE is disabled
 net-misc/lksctp-tools *FLAGS-=-flto* # function `main': <artificial>:(.text.startup+0x16de): undefined reference to `sctp_connectx'

--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -62,6 +62,7 @@ media-video/ffmpeg *FLAGS-=-flto* #NOTE: Depending on your CPUFLAGS this may wor
 media-video/mplayer *FLAGS-=-flto*
 net-libs/webkit-gtk:3 *FLAGS-=-flto*
 net-libs/webkit-gtk:4 *FLAGS-=-flto*
+net-analyzer/wireshark *FLAGS-=-flto* # Segfaults trying to load GUI on QT5, see issue 746
 net-misc/autossh *FLAGS-=-flto* # Undefined references
 net-misc/dhcp "has server ${IUSE//+} && use server && FlagSubAllFlags -flto*" # Cannot be built with LTO by default, but can if "server" USE is disabled
 net-misc/lksctp-tools *FLAGS-=-flto* # function `main': <artificial>:(.text.startup+0x16de): undefined reference to `sctp_connectx'

--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -61,6 +61,7 @@ media-libs/mlt *FLAGS-=-flto*
 media-sound/pulseaudio *FLAGS-=-flto*
 media-video/ffmpeg *FLAGS-=-flto* #NOTE: Depending on your CPUFLAGS this may work with LTO.  The SSE intrinsics seem to cause problems in some cases. Only x86 requires workaround
 media-video/mplayer *FLAGS-=-flto*
+net-analyzer/wireshark *FLAGS-=-flto* # Segfaults trying to load GUI on QT5, see issue 746
 net-libs/webkit-gtk:3 *FLAGS-=-flto*
 net-libs/webkit-gtk:4 *FLAGS-=-flto*
 net-misc/autossh *FLAGS-=-flto* # Undefined references


### PR DESCRIPTION
Fixes #772 and #746 

If it's bad to include 2 fixes in one PR, let me know, this is my first submission to this repo