### PR TITLE
net-libs/nodejs: filter out -flto from *FLAGS; -Ofast workarounds

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -60,6 +60,7 @@ media-libs/mlt *FLAGS-=-flto*
 media-sound/pulseaudio *FLAGS-=-flto*
 media-video/ffmpeg *FLAGS-=-flto* #NOTE: Depending on your CPUFLAGS this may work with LTO.  The SSE intrinsics seem to cause problems in some cases. Only x86 requires workaround
 media-video/mplayer *FLAGS-=-flto*
+net-libs/nodejs *FLAGS-=-flto* # LTO is controlled by a USE flag; currently won't build with LTO and GCC 11 
 net-libs/webkit-gtk:3 *FLAGS-=-flto*
 net-libs/webkit-gtk:4 *FLAGS-=-flto*
 net-misc/autossh *FLAGS-=-flto* # Undefined references

--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -16,6 +16,7 @@ dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MAT
 dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `import matplotlib.pyplot` to fail with `undefined symbol: __log_finite`
 dev-qt/qtcore *FLAGS+='-fno-finite-math-only' # compiles fine but causes most forms of scrolling to stop working in okular
 dev-scheme/guile *FLAGS+='-fno-finite-math-only' # build fails with `floating point exception`
+gui-apps/gammastep *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-math-only causes a runtime error where the brightness values are interpreted incorrectly
 kde-frameworks/kjs /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 <media-libs/opus-1.3.1-r1 /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 media-sound/mumble /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the libopus source throws an error if ffast-math is enabled

--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -9,10 +9,12 @@ sys-apps/systemd /-O3/-O2 # causes homectl to fail with protocol error
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds
+app-editors/emacs *FLAGS+='-fno-finite-math-only' # explicitly required by the ebuild
 dev-lang/python *FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
 dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime errors cause installation of R library tools to fail during emerge
 dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' *FLAGS-='-ffinite-math-only' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python; '-ffinite-math-only' causes incorrect runtime handling of infinite values
 dev-python/pillow *FLAGS+='-fno-finite-math-only' # compiles fine but causes `import matplotlib.pyplot` to fail with `undefined symbol: __log_finite`
+dev-qt/qtcore *FLAGS+='-fno-finite-math-only' # compiles fine but causes most forms of scrolling to stop working in okular
 dev-scheme/guile *FLAGS+='-fno-finite-math-only' # build fails with `floating point exception`
 kde-frameworks/kjs /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 <media-libs/opus-1.3.1-r1 /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
@@ -25,5 +27,4 @@ net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` return
 >=sys-devel/llvm-10.0.0 *FLAGS+='-fno-finite-math-only' # compiles fine but causes clang to fail to emerge with ``undefined reference to `__log10_finite'``
 >=sys-libs/glibc-2.30 /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 x11-misc/redshift *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-math-only causes a runtime error where the brightness values are interpreted incorrectly
-dev-qt/qtcore *FLAGS+='-fno-finite-math-only' # compiles fine but causes most forms of scrolling to stop working in okular
 # END: -Ofast workarounds

--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -27,5 +27,6 @@ net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` return
 >=sys-apps/groff-1.22.4 *FLAGS+='-fsigned-zeros' # causes conflicting declaration of `signbit` compilation error
 >=sys-devel/llvm-10.0.0 *FLAGS+='-fno-finite-math-only' # compiles fine but causes clang to fail to emerge with ``undefined reference to `__log10_finite'``
 >=sys-libs/glibc-2.30 /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
+www-client/firefox /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # won't build with flags activated by -ffast-math on Clang, requires investigation
 x11-misc/redshift *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-math-only causes a runtime error where the brightness values are interpreted incorrectly
 # END: -Ofast workarounds


### PR DESCRIPTION
net-libs/nodejs: There's `lto` USE flag that should be used to inject `-flto` instead, also LTO currently does not work with GCC 11 (you'll be asked to disable the USE flag when you try to emerge it).

app-editors/emacs: You'll be explicitly asked to disable `-ffinite-math-only` during emerge.

gui-apps/gammastep: Fork of `x11-misc/redshift`, `-ffinite-math-only` breaks it in the exactly same way.