### PR TITLE
media-gfx/blender-2.93.2 disable lto

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -145,6 +145,7 @@ dev-qt/qtscript *FLAGS-=-flto* #LTO patch exists, but crashes on newer Qt versio
 dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
 media-libs/mesa "has video_cards_i965 ${IUSE//+} && use video_cards_i965 && FlagSubAllFlags -flto*"
 media-sound/jack2 *FLAGS-=-flto* # segfault in libjack.so.0.1.0 when ANY app trying to use it (breaks everithing built w/ JACK support)
+=media-gfx/blender-2.93.2 *FLAGS-=-flto* # Blender crashes on startup
 net-misc/networkmanager *FLAGS-=-flto* # Test failure
 net-misc/openssh *FLAGS-=-flto* # hangs on exit with lto
 net-news/rssguard *FLAGS-=-flto* # https://bugreports.qt.io/browse/QTBUG-41301 and https://github.com/martinrotter/rssguard/issues/156


### PR DESCRIPTION
Disable lto flag on blender-2.93.2

Version 2.83.17 works fine with lto flag, but version 2.93.2 crashes on
startup. I didn't check other versions.

Backtrace is not very detailed but here it is anyway:
`# backtrace
/usr/bin/blender-2.93(+0xdeb6a0) [0x55c61678c6a0]
/lib64/libc.so.6(+0x38320) [0x7f705b640320]
/usr/bin/blender-2.93(BLI_ghashutil_strhash_p+0) [0x55c618792090]
/usr/bin/blender-2.93(BLI_ghash_insert+0x19) [0x55c618789ff9]
/usr/bin/blender-2.93(ED_operatortypes_screen+0x10) [0x55c6172f6560]
/usr/bin/blender-2.93(ED_spacetypes_init+0x114) [0x55c6173b37a4]
/usr/bin/blender-2.93(WM_init+0x3d0) [0x55c616c12540]
/usr/bin/blender-2.93(main+0x62a) [0x55c61671cc9a]
/lib64/libc.so.6(__libc_start_main+0xcd) [0x7f705b62b7fd]
/usr/bin/blender-2.93(_start+0x2a) [0x55c61676a25a]

# Python backtrace
`
Blender-2.93.2 doesn't crush when I exclude a lot of USE flags like openvbd, but I don't think that the issue is in external libraries.
