### PR TITLE
gui-libs/gtk : Add -ffat-lto-objects

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -114,6 +114,7 @@ dev-lang/moarvm *FLAGS+=-ffat-lto-objects # required for perl6 (i.e., dev-lang/n
 dev-util/cargo *FLAGS+=-ffat-lto-objects # fails to link against git2 functions without
 dev-util/cargo-c *FLAGS+=-ffat-lto-objects # fails to link against ssh functions without
 dev-util/sccache *FLAGS+=-ffat-lto-objects # fails to link
+gui-libs/gtk *FLAGS+=-ffat-lto-objects # Causes media-sound/easyeffects to segfault on open. Seen with gtk 4.4.0 and easyeffects 6.1.3
 media-libs/libvpx *FLAGS+=-ffat-lto-objects # Test failure
 net-libs/quiche *FLAGS+=-ffat-lto-objects # relocation R_X86_64_PC32 against undefined hidden symbol `GFp_ia32cap_P' can not be used when making a shared object
 sci-libs/mpir *FLAGS+=-ffat-lto-objects # compilation error without fat LTO (not linking error)


### PR DESCRIPTION
Causes media-sound/easyeffects to segfault on open without