### PR TITLE
sci-physics/root: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -103,6 +103,7 @@ www-apps/hugo *FLAGS-=-flto*
 www-misc/shellinabox *FLAGS-=-flto*
 x11-base/xorg-server *FLAGS-=-flto* # linking error during compilation
 x11-drivers/xf86-video-intel *FLAGS-=-flto*
+sci-physics/root *FLAGS-="-flto*"
 # END: lto
 
 # BEGIN: ffat-lto-objects


### PR DESCRIPTION
Can't compile these two packages without disabling lto.

There might be a less "hammer + nail" solution, but this change does let them compile and run.
