### PR TITLE
=media-libs/gst-plugins-good-1.18.4: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -57,6 +57,7 @@ mail-filter/procmail *FLAGS-=-flto* # Causes compile to hang indefinitely
 media-gfx/shotwell *FLAGS-=-flto* #Library search error with LTO enabled
 media-libs/alsa-lib *FLAGS-=-flto*
 media-libs/dav1d *FLAGS-=-flto* # Starting with GCC 11.1.0, various undefined reference errors during linking
+=media-libs/gst-plugins-good-1.18.4 *FLAGS-=-flto* # Issue mesonbuild/meson#5482
 media-libs/mlt *FLAGS-=-flto*
 media-sound/pulseaudio *FLAGS-=-flto*
 media-video/ffmpeg *FLAGS-=-flto* #NOTE: Depending on your CPUFLAGS this may work with LTO.  The SSE intrinsics seem to cause problems in some cases. Only x86 requires workaround


### PR DESCRIPTION
Currently, `media-libs/gst-plugins-good-1.18.4` won't build due to an LTO error caused by `gst_yadif_filter_line_mode0_ssse3'.

Ref: https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/issues/909#note_1006399
Ref: mesonbuild/meson#5482
