### PR TITLE
>=media-video/pipewire-0.3.39: disable semantic interposition

### DIFF
--- a/sys-config/ltoize/files/package.cflags/no-semantic-interposition.conf
+++ b/sys-config/ltoize/files/package.cflags/no-semantic-interposition.conf
@@ -5,7 +5,8 @@ app-misc/tracker *FLAGS-="${SEMINTERPOS}" # builds but makes gnome-base/nautilus
 dev-lang/jimtcl *FLAGS-="${SEMINTERPOS}" # buffer overflow error when running an autosetup script.
 dev-lang/swi-prolog *FLAGS-="${SEMINTERPOS}" # segfaults during build
 dev-util/umockdev *FLAGS-="${SEMINTERPOS}" # /usr/include/bits/unistd.h:145:1: error: inlining failed in call to 'always_inline' 'readlink.localalias': function not inlinable
-media-sound/ardour *FLAGS-="${SEMINTERPOS}" # ICE in record_target_from_binfo during GIMPLE pass
+media-sound/ardour *FLAGS-="${SEMINTERPOS}" # ICE in record_target_from_binfo during GIMPLE pass+
+>=media-video/pipewire-0.3.39 *FLAGS-="${SEMINTERPOS}" # starting 0.3.39, cannot not compile
 net-fs/autofs *FLAGS-="${SEMINTERPOS}" # builds but segfault in lookup_file.so
 net-libs/libiscsi *FLAGS-="${SEMINTERPOS}"
 net-print/cups *FLAGS-="${SEMINTERPOS}" # ICE


### PR DESCRIPTION
Compile fails with semantic interposition turned on from `0.3.39` on.
