### PR TITLE
dev-vcs/git: disable -fipa-pta

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ipa-pta.conf
+++ b/sys-config/ltoize/files/package.cflags/ipa-pta.conf
@@ -24,4 +24,5 @@ mail-client/thunderbird *FLAGS-="${IPAPTA}" # ICE with GCC 10.2.0 (seen with thu
 >=dev-lang/spidermonkey-78.3.1 *FLAGS-="${IPAPTA}" # Segfault during build with GCC 10.2.0
 >=media-libs/mesa-21.1.0 *FLAGS-="${IPAPTA}" # Segfault with vulkan
 x11-base/xwayland *FLAGS-="${IPAPTA}" # SIGABRT when querying for GLX information
+>=dev-vcs/git-2.32.0 *FLAGS-="${IPAPTA}" # Segfault in git fetch with GCC < 11.3.0
 # END: -fipa-pta workarounds


### PR DESCRIPTION
Added a workaround for GCC 11.2.0 bug that causes git to be miscompiled with `-flto -fipa-pta`.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101949
https://bugs.gentoo.org/809419
