### PR TITLE
app-misc/openrgb: segmentation fault will occur on launch with LTO enabled

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -157,6 +157,7 @@ sys-apps/sandbox *FLAGS-=-flto* # Issue #347, LTO breaks basic sandboxing functi
 sys-fs/cryfs *FLAGS-=-flto* # Test failure
 sys-libs/libapparmor *FLAGS-=-flto* # Undefined symbol error when trying to compile sys-apps/apparmor
 sys-libs/libxcrypt *FLAGS-=-flto* # Undefined symbols in library files cause dependencies like net-misc/whois to fail to build
+app-misc/openrgb *FLAGS-=-flto* # Segmentation fault on launch
 # END: LTO not recommended
 
 # BEGIN: Build Workarounds


### PR DESCRIPTION
app-misc/openrgb will complete build successfully however will generate a core dump due to a segmentation fault, on launch.