### PR TITLE
kde-apps/cantor: will not build with -O3

### DIFF
--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -6,6 +6,7 @@ media-libs/lcms /-O3/-O2 # Test failure
 net-misc/dhcp /-O3/-O2 # Runtime failure, DHCPDISCOVER doesn't work correctly - introduced with gcc 10?
 sci-libs/scotch /-O3/-O2 # Test failure
 sys-apps/systemd /-O3/-O2 # causes homectl to fail with protocol error
+kde-apps/cantor /-O3/-O2 # Build fails with error
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds


### PR DESCRIPTION
kde-apps/cantor will fail build with -O3 but works perfectly fine with -O2, graphite, and other optimizations enabled by ltoize.