### PR TITLE
app-containers/snapd: will not build with -O3

### DIFF
--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -7,6 +7,7 @@ net-misc/dhcp /-O3/-O2 # Runtime failure, DHCPDISCOVER doesn't work correctly - 
 sci-libs/scotch /-O3/-O2 # Test failure
 sys-apps/systemd /-O3/-O2 # causes homectl to fail with protocol error
 kde-apps/cantor /-O3/-O2 # Build fails with error
+app-containers/snapd /-O3/-O2 # Build fails with stringop-overflow
 # END: Deliberate -O3 workarounds
 
 # BEGIN: -Ofast workarounds


### PR DESCRIPTION
When building snapd with -O3, the build will fail due to a stringop-overflow.