### PR TITLE
dev-db/postgresql: disable lto

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -20,6 +20,7 @@ cross-x86_64-w64-mingw32/mingw64-runtime *FLAGS-=-flto* # linking errors
 dev-db/firebird *FLAGS-=-flto*
 dev-db/mariadb *FLAGS-=-flto*
 dev-db/mysql-connector-c *FLAGS-=-flto* # required to compiled mysql-connector-c
+dev-db/postgresql *FLAGS-=-flto* # error: inlining failed in call to ‘always_inline’ ‘_mm_crc32_u8’
 games-fps/gzdoom *FLAGS-=-flto* # Assertion `Class != nullptr' failed. SIGABRT
 games-fps/zandronum *FLAGS-=-flto* #Can't read wads properly with LTO
 dev-java/icedtea *FLAGS-=-flto*


### PR DESCRIPTION
I was having an issue compiling dev-db/postgresql with lto. 
Disabling lto seems to fix the issue. 