### PR TITLE
media-video/obs-studio: Disable O3

### DIFF
--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -3,6 +3,7 @@ kde-frameworks/kactivities-stats /-O3/-O2 # causes systemsettings5 to crash
 mail-filter/procmail /-O3/-O2 # Causes compile to hang indefinitely
 media-libs/faad2 *FLAGS+=-fno-tree-loop-vectorize # causes subtly wrong decoding
 media-libs/lcms /-O3/-O2 # Test failure
+media-video/obs-studio /-O3/-O2 # Seems to work fine at first, however, crashes with "malloc(): invalid size (unsorted)" when attempting to start stream, GCC 11.2
 net-misc/dhcp /-O3/-O2 # Runtime failure, DHCPDISCOVER doesn't work correctly - introduced with gcc 10?
 sci-libs/scotch /-O3/-O2 # Test failure
 sys-apps/systemd /-O3/-O2 # causes homectl to fail with protocol error


### PR DESCRIPTION
Seems to work fine at first, however, crashes with "malloc(): invalid size (unsorted)" when attempting to start stream, GCC 11.2.

I'm not skilled enough to debug it further, changing O3 to O2 fixes the issue, if you believe that you have necessary skills, willings and time to tackle it down, you're more than welcome to do so, but until then this PR should do the trick.