### PR TITLE
net-libs/webkit-gtk: Fix compilation error caused by -stdlib=libstdc++

### DIFF
--- a/sys-config/ltoize/files/package.cflags/clang.conf
+++ b/sys-config/ltoize/files/package.cflags/clang.conf
@@ -12,5 +12,5 @@ media-libs/libglvnd LTO_FULL=1 # ld.lld: error: undefined symbol: entrypointFunc
 
 # BEGIN: Packages which require libstdc++
 media-libs/exempi CXXFLAGS+=-stdlib=libstdc++ # fatal error: 'tr1/memory' file not found
-net-libs/webkit-gtk CXXFLAGS+=-stdlib=libstdc++ # error: use of undeclared identifier 'LC_ALL'
+#net-libs/webkit-gtk CXXFLAGS+=-stdlib=libstdc++ # error: use of undeclared identifier 'LC_ALL' # error: unrecognized command-line option ‘-stdlib=libstdc++’
 # END: Packages which require libstdc++


### PR DESCRIPTION
Title: net-libs/webkit-gtk: Fix compilation error caused by -stdlib=libstdc++

net-libs/webkit-gtk doesn't pass the tests set by g++, therefore compilation fails.
[Here's](https://github.com/InBetweenNames/gentooLTO/issues/808) the GitHub issue.