### PR TITLE
dev-util/cargo-ebuild: fix error at build

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -113,6 +113,7 @@ dev-haskell/* *FLAGS+=-ffat-lto-objects #This is so non-portage GHC compilations
 dev-lang/moarvm *FLAGS+=-ffat-lto-objects # required for perl6 (i.e., dev-lang/nqp and dev-lang/rakudo to build)
 dev-util/cargo *FLAGS+=-ffat-lto-objects # fails to link against git2 functions without
 dev-util/cargo-c *FLAGS+=-ffat-lto-objects # fails to link against ssh functions without
+dev-util/cargo-ebuild *FLAGS+=-ffat-lto-objects # fails to link against git2 functions without
 dev-util/sccache *FLAGS+=-ffat-lto-objects # fails to link
 media-libs/libvpx *FLAGS+=-ffat-lto-objects # Test failure
 net-libs/quiche *FLAGS+=-ffat-lto-objects # relocation R_X86_64_PC32 against undefined hidden symbol `GFp_ia32cap_P' can not be used when making a shared object


### PR DESCRIPTION
Fixes a failure to link against git2 functions.