### PR TITLE
dev-lang/ldc2::dlang: doesn't take -flto

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -25,6 +25,7 @@ games-fps/zandronum *FLAGS-=-flto* #Can't read wads properly with LTO
 dev-java/icedtea *FLAGS-=-flto*
 <dev-java/openjdk-14 *FLAGS-=-flto* # Issue #204, undefined references with LTO.
 dev-lang/erlang *FLAGS-=-flto* # Starting with Erlang 24.0, yeccparser.erl: internal error in pass beam_kernel_to_ssa
+dev-lang/ldc2::dlang *FLAGS-=-flto* # Necessary for both ldc2-1.29.0 and ldc2-1.30.0
 dev-lang/lua *FLAGS-=-flto* # Causes issues building packages like neovim and awesomewm, fixes #772
 dev-lang/mono *FLAGS-=-flto*
 dev-lang/perl *FLAGS-=-flto*

--- a/sys-config/ltoize/files/package.cflags/portage-bashrc-mv.conf
+++ b/sys-config/ltoize/files/package.cflags/portage-bashrc-mv.conf
@@ -1,3 +1,4 @@
 # BEGIN: portage-bashrc-mv remove-la workarounds
 dev-util/colm NOLAFILEREMOVE=true # See issue 690 and https://bugs.gentoo.org/766210
+dev-util/dub::dlang NOCADD=1 # Avoid tainting LDFLAGS for D compilers - see portage-bashrc-mv docs
 # END: portage-bashrc-mv remove-la workarounds

--- a/sys-config/ltoize/files/package.cflags/portage-bashrc-mv.conf
+++ b/sys-config/ltoize/files/package.cflags/portage-bashrc-mv.conf
@@ -1,4 +1,3 @@
 # BEGIN: portage-bashrc-mv remove-la workarounds
 dev-util/colm NOLAFILEREMOVE=true # See issue 690 and https://bugs.gentoo.org/766210
-dev-util/dub::dlang NOCADD=1 # Avoid tainting LDFLAGS for D compilers - see portage-bashrc-mv docs
 # END: portage-bashrc-mv remove-la workarounds


### PR DESCRIPTION
Please note: this concerns dlang overlay. I don't now about gentooLTO project policies in terms of overlays.

This commit fixes ldc2 D compiler. Tested both 1.29.0 and 1.30.0.
[log.txt](https://github.com/InBetweenNames/gentooLTO/files/9536461/log.txt)
