### PR TITLE
dev-lang/ldc2::dlang: required -ffat-lto-objects

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -110,6 +110,7 @@ x11-drivers/xf86-video-intel *FLAGS-=-flto*
 app-crypt/efitools *FLAGS+=-ffat-lto-objects # textrel?
 app-editors/vim "has perl ${IUSE//+} && use perl && FlagAddAllFlags -ffat-lto-objects" # required for perl USE flag
 dev-haskell/* *FLAGS+=-ffat-lto-objects #This is so non-portage GHC compilations work, as GHC is oblivious to LTO.  portage builds are fine.
+dev-lang/ldc2::dlang *FLAGS+=-ffat-lto-objects # Required by ldc2-1.29.0 and ldc2-1.30.0
 dev-lang/moarvm *FLAGS+=-ffat-lto-objects # required for perl6 (i.e., dev-lang/nqp and dev-lang/rakudo to build)
 dev-util/cargo *FLAGS+=-ffat-lto-objects # fails to link against git2 functions without
 dev-util/cargo-c *FLAGS+=-ffat-lto-objects # fails to link against ssh functions without


### PR DESCRIPTION
dev-lang/ldc2 is from dlang overlay. Requires -ffat-lto-objects to compile, otherwise it fails with lots of unrecognized symbols.

This is a compiler so it definitely requires further tests to ensure that everything works fine.

[build.log](https://github.com/InBetweenNames/gentooLTO/files/9543469/build.log)
