### PR TITLE
dev-lang/duktape: disable Ofast

### DIFF
--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -11,6 +11,7 @@ kde-apps/cantor /-O3/-O2 # Build fails with error
 
 # BEGIN: -Ofast workarounds
 app-editors/emacs *FLAGS+='-fno-finite-math-only' # explicitly required by the ebuild
+dev-lang/duktape /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # Build fails with error
 dev-lang/python *FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
 dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime errors cause installation of R library tools to fail during emerge
 dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' *FLAGS-='-ffinite-math-only' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python; '-ffinite-math-only' causes incorrect runtime handling of infinite values

--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -11,7 +11,7 @@ kde-apps/cantor /-O3/-O2 # Build fails with error
 
 # BEGIN: -Ofast workarounds
 app-editors/emacs *FLAGS+='-fno-finite-math-only' # explicitly required by the ebuild
-dev-lang/duktape /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # Build fails with error
+dev-lang/duktape /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 dev-lang/python *FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
 dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime errors cause installation of R library tools to fail during emerge
 dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' *FLAGS-='-ffinite-math-only' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python; '-ffinite-math-only' causes incorrect runtime handling of infinite values

--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -11,7 +11,7 @@ kde-apps/cantor /-O3/-O2 # Build fails with error
 
 # BEGIN: -Ofast workarounds
 app-editors/emacs *FLAGS+='-fno-finite-math-only' # explicitly required by the ebuild
-dev-lang/duktape /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
+dev-lang/duktape /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if __FAST_MATH__ macro is defined
 dev-lang/python *FLAGS+='-fno-finite-math-only' # instrumentation tests hang/segfault during emerge
 dev-lang/R *FLAGS+='-fno-finite-math-only' # R itself compiles fine, but runtime errors cause installation of R library tools to fail during emerge
 dev-python/numpy /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' /-funsafe-math-optimizations/'${SAFER_UNSAFE_MATH_OPTS}' *FLAGS-='-ffinite-math-only' # no compilation error, but -funsafe-math-optimizations (implied by -Ofast or -ffast-math) causes an undefined symbol error when trying to import numpy in python; '-ffinite-math-only' causes incorrect runtime handling of infinite values


### PR DESCRIPTION
Can't compile with macro \_\_FAST_MATH\_\_.
