### PR TITLE
sys-apps/systemd: disable Ofast

### DIFF
--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -26,6 +26,7 @@ net-analyzer/rrdtool *FLAGS+='-fno-finite-math-only' # configure fails due to no
 net-libs/nodejs *FLAGS+='-fno-finite-math-only' # compiles fine but `npm` returns error whenever it starts running
 >=sys-apps/coreutils-8.31 *FLAGS+='-fno-finite-math-only' # causes multiple definition of `minus_zero` error during linking
 >=sys-apps/groff-1.22.4 *FLAGS+='-fsigned-zeros' # causes conflicting declaration of `signbit` compilation error
+sys-apps/systemd /-Ofast/'-O2 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # configure fails with error
 >=sys-devel/llvm-10.0.0 *FLAGS+='-fno-finite-math-only' # compiles fine but causes clang to fail to emerge with ``undefined reference to `__log10_finite'``
 >=sys-libs/glibc-2.30 /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 www-client/firefox /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # won't build with flags activated by -ffast-math on Clang, requires investigation


### PR DESCRIPTION
Configure fails with error.
