### PR TITLE
media-libs/rnnoise: disable Ofast

### DIFF
--- a/sys-config/ltoize/files/package.cflags/optimizations.conf
+++ b/sys-config/ltoize/files/package.cflags/optimizations.conf
@@ -20,6 +20,7 @@ dev-scheme/guile *FLAGS+='-fno-finite-math-only' # build fails with `floating po
 gui-apps/gammastep *FLAGS+='-fno-finite-math-only' # compiles fine but -ffinite-math-only causes a runtime error where the brightness values are interpreted incorrectly
 kde-frameworks/kjs /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 <media-libs/opus-1.3.1-r1 /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
+media-libs/rnnoise /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the source throws an error if ffast-math is enabled
 media-sound/mumble /-Ofast/'-O3 ${SAFER_FAST_MATH}' /-ffast-math/'${SAFER_FAST_MATH}' # preprocessor in the libopus source throws an error if ffast-math is enabled
 media-video/mpv /-Ofast/'-O3 ${SAFEST_FAST_MATH}' /-ffast-math/'${SAFEST_FAST_MATH}' # causes incorrect behavior (black screen) when enabling interpolation or downscaling
 net-analyzer/rrdtool *FLAGS+='-fno-finite-math-only' # configure fails due to non-compliant IEEE arithmetic


### PR DESCRIPTION
Preprocessor in the source throws an error if ffast-math is enabled.
