### PR TITLE
app-misc/openrgb-plugin-effects: disable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -158,6 +158,7 @@ sys-fs/cryfs *FLAGS-=-flto* # Test failure
 sys-libs/libapparmor *FLAGS-=-flto* # Undefined symbol error when trying to compile sys-apps/apparmor
 sys-libs/libxcrypt *FLAGS-=-flto* # Undefined symbols in library files cause dependencies like net-misc/whois to fail to build
 app-misc/openrgb *FLAGS-=-flto* # Segmentation fault on launch
+app-misc/openrgb-plugin-effects *FLAGS-=-flto* # Segmentaion fault on launch
 # END: LTO not recommended
 
 # BEGIN: Build Workarounds


### PR DESCRIPTION
Compiling the openrgb effects plugin with LTO enabled causes openrgb to crash with a segmentation fault on startup.