### PR TITLE
app-office/gnucash: disable semantic interposition

### DIFF
--- a/sys-config/ltoize/files/package.cflags/no-semantic-interposition.conf
+++ b/sys-config/ltoize/files/package.cflags/no-semantic-interposition.conf
@@ -13,4 +13,6 @@ net-print/cups *FLAGS-="${SEMINTERPOS}" # ICE
 sys-devel/llvm *FLAGS-="${SEMINTERPOS}"
 sys-libs/glibc *FLAGS-="${SEMINTERPOS}"
 sys-libs/readline *FLAGS-="${SEMINTERPOS}" # breaks ncurses for some users, #681 #392
+app-office/gnucash *FLAGS-="${SEMINTERPOS}" # does not build, storing address of local variable error
 # END: Semantic Interposition Workarounds
+


### PR DESCRIPTION
Issue: https://github.com/InBetweenNames/gentooLTO/issues/874

Error during build is:

```
/var/tmp/portage/app-office/gnucash-4.12-r1/work/gnucash-4.12/libgnucash/engine/qofid.cpp:301:19: error: storing the address of local variable ‘value’ in ‘*(QofCollection*)user_data.QofCollection_s::data’ [-Werror=dangling-pointer=]
  301 |         col->data = user_data;
      |         ~~~~~~~~~~^~~~~~~~~~~
/var/tmp/portage/app-office/gnucash-4.12-r1/work/gnucash-4.12/libgnucash/engine/qofid.cpp: In function ‘void collection_compare_cb(QofInstance*, gpointer)’:
/var/tmp/portage/app-office/gnucash-4.12-r1/work/gnucash-4.12/libgnucash/engine/qofid.cpp:144:10: note: ‘value’ declared here
  144 |     gint value;
      |          ^~~~~
/var/tmp/portage/app-office/gnucash-4.12-r1/work/gnucash-4.12/libgnucash/engine/qofid.cpp:144:10: note: ‘user_data’ declared here
```