### PR TITLE
dev-python/cryptography: diable LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -141,6 +141,7 @@ dev-libs/libbsd *FLAGS-=-flto* # Undefined symbol error when building mail-clien
 dev-libs/libpcre *FLAGS-=-flto* # Test failure
 dev-libs/protobuf *FLAGS-=-flto* #Upstream bug https://github.com/protocolbuffers/protobuf/issues/4958
 dev-libs/rocr-runtime *FLAGS-=-flto* # Causes crashes in multiple OpenCL tools
+dev-python/cryptography *FLAGS-=-flto* # Undefined symbol PyInit__openssl due to GCC versus LLVM/Clang LTO https://github.com/pyca/cryptography/issues/9023
 dev-qt/qtscript *FLAGS-=-flto* #LTO patch exists, but crashes on newer Qt versions.  Needs to be updated.
 dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
 media-libs/mesa "has video_cards_i965 ${IUSE//+} && use video_cards_i965 && FlagSubAllFlags -flto*"


### PR DESCRIPTION
Causes "_rust.abi3.so: undefined symbol: PyInit__openssl" due to LTO conflict when using GCC for C/C++ and Clang/LLVM for Rust. Only started with 41.0.1 for me but Gentoo bug references 40.0.1.

https://bugs.gentoo.org/903908
https://github.com/pyca/cryptography/issues/9023

Unfortunately likely to be something that'll occur more frequently as Rust pervades more packages (or until GCC can compile Rust).