### PR TITLE
add new overrides for arm64

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -54,6 +54,7 @@ gnustep-base/gnustep-make *FLAGS-=-flto* # Issue #581, tools to build gnustep-ba
 kde-apps/kdenlive *FLAGS-=-flto*
 kde-frameworks/kjs *FLAGS-=-flto* # Issue #181
 mail-filter/procmail *FLAGS-=-flto* # Causes compile to hang indefinitely
+media-gfx/potrace *FLAGS-=-flto* # asm link: Error: unknown mnemonic
 media-gfx/shotwell *FLAGS-=-flto* #Library search error with LTO enabled
 media-libs/alsa-lib *FLAGS-=-flto*
 media-libs/dav1d *FLAGS-=-flto* # Starting with GCC 11.1.0, various undefined reference errors during linking


### PR DESCRIPTION
* media-gfx/potrace, asm code: Error: unknown mnemonic

bugs:
  potrace: https://bugs.gentoo.org/868465

This is still a rebuild-in-progress on arm64 so I was planning on adding any additional fails to this PR.  Then I read the issue comments about one-per-bug so...  Are you okay with more than one pkg/override in a single issue?  Thanks in advance!
