### PR TITLE
Disable LTO for two rocm packages

### DIFF
--- a/sys-config/ltoize/files/package.cflags/lto.conf
+++ b/sys-config/ltoize/files/package.cflags/lto.conf
@@ -1,5 +1,7 @@
 # BEGIN: lto
 # Packages which cannot be built with LTO at all
+dev-util/rocm-smi *FLAGS-=-flto*
+dev-util/hip *FLAGS-=-flto*
 app-admin/keepassxc *FLAGS-=-flto* # segfaults on start since Qt 5.15.1
 app-emulation/dosemu *FLAGS-=-flto* # Issue #163
 app-emulation/libguestfs *FLAGS-=-flto*


### PR DESCRIPTION
These currently cannot be built with LTO